### PR TITLE
add tiny sleep in the main server loop to avoid using 100% cpu on nothing

### DIFF
--- a/SERVER/src/network/Server.java
+++ b/SERVER/src/network/Server.java
@@ -237,6 +237,12 @@ public abstract class Server {
 				ticksCount = 0;
 				//ServerMessage.printMessage("Ticks/Second: " + actualTPS);				
 			}
+			
+			try {
+				Thread.currentThread().sleep(10L);
+			} catch (InterruptedException ex) {
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
it is better to use the cpu on client threads than in the tight timing loop.
