### PR TITLE
use buffers for string concatenation to avoid too many java objects creations

### DIFF
--- a/SERVER/src/creature/Creature.java
+++ b/SERVER/src/creature/Creature.java
@@ -353,22 +353,17 @@ public class Creature implements Mover {
 	
 	
 	public String getFullData(){
-		
-		String creatureData = getSmallData()+","+getName()+","+getEquipmentInfo()+","+getHealthStatus()+","+getStat("SPEED");
-		
-		creatureData += ","+getCustomization().getMouthFeatureId()+","+getCustomization().getAccessoriesId()+","+getCustomization().getSkinFeatureId();
-		
-		if(isResting()){
-			creatureData += ",1";
-		}else{
-			creatureData += ",0";
-		}
+
+		String creatureData = getSmallData()+','+getName()+','+getEquipmentInfo()+','+getHealthStatus()+','+getStat("SPEED")
+						+ ','+getCustomization().getMouthFeatureId()+','+getCustomization().getAccessoriesId()+','
+						+getCustomization().getSkinFeatureId()
+						+ (isResting() ? ",1" : ",0");
 		
 		return creatureData;
 	}
 	
 	public String getSmallData(){
-		String newCreatureData = getCreatureType().toString()+","+getDBId()+","+getCreatureId()+","+getX()+","+getY()+","+getZ()+","+getRotation();
+		String newCreatureData = getCreatureType().toString()+','+getDBId()+','+getCreatureId()+','+getX()+','+getY()+','+getZ()+','+getRotation();
 		return newCreatureData;
 	}
 	
@@ -426,34 +421,33 @@ public class Creature implements Mover {
 
 	public String getBonusStatsAsString(){
 		
-		String bonusStats = "";
+		StringBuilder bonusStats = new StringBuilder(1000);
 		
-		bonusStats += BonusStats.getValue("STRENGTH") + ",";
-		bonusStats += BonusStats.getValue("INTELLIGENCE") + ",";
-		bonusStats += BonusStats.getValue("AGILITY") + ",";
-		bonusStats += BonusStats.getValue("SPEED") + ",";
+		bonusStats.append(BonusStats.getValue("STRENGTH")).append(',')
+		          .append(BonusStats.getValue("INTELLIGENCE")).append(',')
+		          .append(BonusStats.getValue("AGILITY")).append(',')
+		          .append(BonusStats.getValue("SPEED")).append(',')
 		
-		bonusStats += BonusStats.getValue("CRITICAL_HIT") + ",";
-		bonusStats += BonusStats.getValue("EVASION") + ",";
-		bonusStats += BonusStats.getValue("ACCURACY") + ",";
+		          .append(BonusStats.getValue("CRITICAL_HIT")).append(',')
+		          .append(BonusStats.getValue("EVASION")).append(',')
+		          .append(BonusStats.getValue("ACCURACY")).append(',')
 		
-		bonusStats += BonusStats.getValue("MAX_HEALTH") + ",";
-		bonusStats += BonusStats.getValue("MAX_MANA") + ",";
+		          .append(BonusStats.getValue("MAX_HEALTH")).append(',')
+		          .append(BonusStats.getValue("MAX_MANA")).append(',')
 		
-		bonusStats += BonusStats.getValue("FIRE_DEF") + ",";
-		bonusStats += BonusStats.getValue("COLD_DEF") + ",";
-		bonusStats += BonusStats.getValue("SHOCK_DEF") + ",";
-		bonusStats += BonusStats.getValue("CHEMS_DEF") + ",";
-		bonusStats += BonusStats.getValue("MIND_DEF") + ",";
-		bonusStats += BonusStats.getValue("ARMOR") + ",";
+		          .append(BonusStats.getValue("FIRE_DEF")).append(',')
+		          .append(BonusStats.getValue("COLD_DEF")).append(',')
+		          .append(BonusStats.getValue("SHOCK_DEF")).append(',')
+		          .append(BonusStats.getValue("CHEMS_DEF")).append(',')
+		          .append(BonusStats.getValue("MIND_DEF")).append(',')
+		          .append(BonusStats.getValue("ARMOR")).append(',')
 		
-		bonusStats += getAttackSpeed() + ",";
+		          .append(getAttackSpeed()).append(',')
 		
-		bonusStats += BonusStats.getValue("HEALTH_REGAIN") + ",";
-		bonusStats += BonusStats.getValue("MANA_REGAIN");
+		          .append(BonusStats.getValue("HEALTH_REGAIN")).append(',')
+		          .append(BonusStats.getValue("MANA_REGAIN"));
 		
-		
-		return bonusStats;
+		return bonusStats.toString();
 	}
 	
 	public synchronized void addStatusEffect(StatusEffect newStatusEffect){
@@ -806,46 +800,44 @@ public class Creature implements Mover {
 	
 	public String getEquipmentInfo() {
 		
-		String info = "";
+		StringBuilder info = new StringBuilder();
 		
 		if(HeadItem != null){
-			info += HeadItem.getId()+",";
+			info.append(HeadItem.getId()).append(',');
 		}else {
-			info += "0,";
+			info.append("0,");
 		}
-		info += getCustomization().getHeadSkinId()+",";
+		info.append(getCustomization().getHeadSkinId()).append(',');
 		
 		if(WeaponItem != null){
-			info += WeaponItem.getId()+",";
+			info.append(WeaponItem.getId()).append(',');
 		}else {
-			info += "0,";
+			info.append("0,");
 		}
-		info += getCustomization().getWeaponSkinId()+",";
+		info.append(getCustomization().getWeaponSkinId()).append(',');
 		
 		if(OffHandItem != null){
-			info += OffHandItem.getId()+",";
+			info.append(OffHandItem.getId()).append(',');
 		}else {
-			info += "0,";
+			info.append("0,");
 		}
-		info += getCustomization().getOffHandSkinId()+",";
+		info.append(getCustomization().getOffHandSkinId()).append(',');
 		
 		if(AmuletItem != null){
-			info += AmuletItem.getId()+",";
+			info.append(AmuletItem.getId()).append(',');
 		}else {
-			info += "0,";
+			info.append("0,");
 		}
-		info += getCustomization().getAmuletSkinId()+",";
+		info.append(getCustomization().getAmuletSkinId()).append(',');
 		
 		if(ArtifactItem != null){
-			info += ArtifactItem.getId()+",";
+			info.append(ArtifactItem.getId()).append(',');
 		}else {
-			info += "0,";
+			info.append("0,");
 		}
-		info += getCustomization().getArtifactSkinId();
+		info.append(getCustomization().getArtifactSkinId());
 		
-		
-		
-		return info;
+		return info.toString();
 	}
 	
 

--- a/SERVER/src/creature/PlayerCharacter.java
+++ b/SERVER/src/creature/PlayerCharacter.java
@@ -242,53 +242,56 @@ public class PlayerCharacter extends Creature {
 
 	public String getInfo(){
 		// x, y, z, 
-		String info = X+","+Y+","+Z+","+Bounty+","+PlayerKillerTime;
+		StringBuilder info = new StringBuilder(1000);
+		info.append(X).append(',')
+		    .append(Y).append(',')
+		    .append(Z).append(',')
+		    .append(Bounty).append(',')
+		    .append(PlayerKillerTime)
+		
+		    .append(':')
+		
+		    .append(CreatureId).append(',')
+		    .append(Name).append(',')
+		    .append(Family).append(',')
+		    .append(AttackType).append(',')
+		    .append(Level).append(',')
+		    .append(XP).append(',')
 
+		    .append(Stats.getValue("STRENGTH")).append(',')
+		    .append(Stats.getValue("INTELLIGENCE")).append(',')
+		    .append(Stats.getValue("AGILITY")).append(',')
+		    .append(Stats.getValue("SPEED")).append(',')
+		
+		    .append(Stats.getValue("CRITICAL_HIT")).append(',')
+		    .append(Stats.getValue("EVASION")).append(',')
+		    .append(Stats.getValue("ACCURACY")).append(',')
 
-		info += ":";
+		    .append(Stats.getValue("MAX_HEALTH")).append(',')
+		    .append(Health).append(',')
+		    .append(Stats.getValue("MAX_MANA")).append(',')
+		    .append(Mana).append(',')
 
-		info += CreatureId+",";
-		info += Name+",";
-		info += Family+",";
+		    .append(Stats.getValue("FIRE_DEF")).append(',')
+		    .append(Stats.getValue("COLD_DEF")).append(',')
+		    .append(Stats.getValue("SHOCK_DEF")).append(',')
+		    .append(Stats.getValue("CHEMS_DEF")).append(',')
+		    .append(Stats.getValue("MIND_DEF")).append(',')
+		    .append(Stats.getValue("MAGIC_DEF")).append(',')
 
-		info += AttackType+",";
-		info += Level+",";
-		info += XP+",";
+		    .append(Stats.getValue("ARMOR")).append(',')
 
-		info += Stats.getValue("STRENGTH")+",";
-		info += Stats.getValue("INTELLIGENCE")+",";
-		info += Stats.getValue("AGILITY")+",";
-		info += Stats.getValue("SPEED")+",";
+		    .append(nextXP).append(',')
 
-		info += Stats.getValue("CRITICAL_HIT")+",";
-		info += Stats.getValue("EVASION")+",";
-		info += Stats.getValue("ACCURACY")+",";
+		    .append(dbId).append(',')
 
-		info += Stats.getValue("MAX_HEALTH")+",";
-		info += Health+",";
-		info += Stats.getValue("MAX_MANA")+",";
-		info += Mana+",";
-
-		info += Stats.getValue("FIRE_DEF")+",";
-		info += Stats.getValue("COLD_DEF")+",";
-		info += Stats.getValue("SHOCK_DEF")+",";
-		info += Stats.getValue("CHEMS_DEF")+",";
-		info += Stats.getValue("MIND_DEF")+",";
-		info += Stats.getValue("MAGIC_DEF")+",";
-
-		info += Stats.getValue("ARMOR")+",";
-
-		info += nextXP+",";
-
-		info += dbId+",";
-
-		info += getAttackRange()+",";
-		info += getHealthStatus()+",";
+		    .append(getAttackRange()).append(',')
+		    .append(getHealthStatus()).append(',')
 
 		// CREW INFO
-		info += Crew.getId()+",";
-		info += Crew.getName()+",";
-		info += Crew.getMemberState()+",";
+		    .append(Crew.getId()).append(',')
+		    .append(Crew.getName()).append(',')
+		    .append(Crew.getMemberState()).append(',');
 
 		// SHIP INFO
 		int shipId = 0;
@@ -296,30 +299,30 @@ public class PlayerCharacter extends Creature {
 		if(getShip() != null){
 			shipId = getShip().getShipId();
 		}
-		info += shipId+",";
-
-		info += getPkMarker()+",";
+		info.append(shipId).append(',')
+		
+		    .append(getPkMarker()).append(',')
 		
 		// Classes info
-		info += baseClass.id+",";
+		    .append(baseClass.id).append(',');
 		
 		for(BaseClass baseClass: ServerGameInfo.classDef.values()){
 			if(baseClass.available){
 				BaseClass playerClass = playerClasses.get(baseClass.id);
-				info += playerClass.level+","+playerClass.getXp()+","+playerClass.nextXP;
+				info.append(playerClass.level).append(',')
+				    .append(playerClass.getXp()).append(',')
+				    .append(playerClass.nextXP);
 				if(primaryClass != null && primaryClass.id == playerClass.id){
-					info += ",1,";
+					info.append(",1,");
 				}else if(secondaryClass != null && secondaryClass.id == playerClass.id){
-					info += ",2,";
+					info.append(",2,");
 				}else{
-					info += ",0,";
+					info.append(",0,");
 				}
 			}
 		}
 		
-		info += getAdminLevel();
-
-		info += "/";
+		info.append(getAdminLevel()).append('/');
 
 		// SEND EQUIPMENT INFO
 
@@ -330,42 +333,60 @@ public class PlayerCharacter extends Creature {
 		Item ArtifactItem = getEquipment("Artifact");
 
 		if(HeadItem != null){
-			info += HeadItem.getId()+","+getCustomization().getHeadSkinId()+","+HeadItem.getClassId()+",";
+			info.append(HeadItem.getId()).append(',')
+					.append(getCustomization().getHeadSkinId()).append(',')
+					.append(HeadItem.getClassId()).append(',');
 		}else{
-			info += "0,"+getCustomization().getHeadSkinId()+",0,";
+			info.append("0,")
+			    .append(getCustomization().getHeadSkinId())
+			    .append(",0,");
 		}
 
 		if(WeaponItem != null){
-			info += WeaponItem.getId()+","+getCustomization().getWeaponSkinId()+","+WeaponItem.getClassId()+",";
+			info.append(WeaponItem.getId()).append(',')
+					.append(getCustomization().getWeaponSkinId()).append(',')
+					.append(WeaponItem.getClassId()).append(',');
 		}else{
-			info += "0,"+getCustomization().getWeaponSkinId()+",0,";
+			info.append("0,")
+			    .append(getCustomization().getWeaponSkinId())
+			    .append(",0,");
 		}
 
 		if(OffHandItem != null){
-			info += OffHandItem.getId()+","+getCustomization().getOffHandSkinId()+","+OffHandItem.getClassId()+",";
+			info.append(OffHandItem.getId()).append(',')
+					.append(getCustomization().getOffHandSkinId()).append(',')
+					.append(OffHandItem.getClassId()).append(',');
 		}else{
-			info += "0,"+getCustomization().getOffHandSkinId()+",0,";
+			info.append("0,")
+			    .append(getCustomization().getOffHandSkinId())
+			    .append(",0,");
 		}
 
 		if(AmuletItem != null){
-			info += AmuletItem.getId()+","+getCustomization().getAmuletSkinId()+","+AmuletItem.getClassId()+",";
+			info.append(AmuletItem.getId()).append(',')
+					.append(getCustomization().getAmuletSkinId()).append(',')
+					.append(AmuletItem.getClassId()).append(',');
 		}else{
-			info += "0,"+getCustomization().getAmuletSkinId()+",0,";
+			info.append("0,")
+			    .append(getCustomization().getAmuletSkinId())
+			    .append(",0,");
 		}
 
 		if(ArtifactItem != null){
-			info += ArtifactItem.getId()+","+getCustomization().getArtifactSkinId()+","+ArtifactItem.getClassId()+",";
+			info.append(ArtifactItem.getId()).append(',')
+					.append(getCustomization().getArtifactSkinId()).append(',')
+					.append(ArtifactItem.getClassId()).append(',');
 		}else{
-			info += "0,"+getCustomization().getArtifactSkinId()+",0,";
+			info.append("0,")
+			    .append(getCustomization().getArtifactSkinId())
+			    .append(",0,");
 		}
 
+		info.append(getCustomization().getMouthFeatureId()).append(',')
+		    .append(getCustomization().getAccessoriesId()).append(',')
+		    .append(getCustomization().getSkinFeatureId());
 
-		info += getCustomization().getMouthFeatureId()+",";
-		info += getCustomization().getAccessoriesId()+",";
-		info += getCustomization().getSkinFeatureId();
-
-
-		return info;
+		return info.toString();
 	}
 
 	// INFO TO SEND TO OTHER CLIENTS

--- a/SERVER/src/data_handlers/DataHandlers.java
+++ b/SERVER/src/data_handlers/DataHandlers.java
@@ -95,8 +95,8 @@ public class DataHandlers {
 		for(Iterator<Message> i = incomingMessages.iterator(); i.hasNext(); ) {
 			Message m = i.next();
 
-			Client client = m.getClient();
-			String message = "<"+m.getType()+">"+m.getMessage();
+			Client client = m.client;
+			String message = "<"+m.type+">"+m.message;
 
 			ConnectHandler.handleData(client, message);
 
@@ -165,11 +165,11 @@ public class DataHandlers {
 
 	private static boolean sendMessage(Message message){
 		boolean sendOk = true;
-		Client client = message.getClient();
+		Client client = message.client;
 
 		try{
 			try{
-				String dataToSend = "<"+message.getType()+">"+message.getMessage();
+				String dataToSend = "<"+message.type+">"+message.message;
 				
 				byte[] byteMsg = (dataToSend).getBytes();
 				if(client.out != null){

--- a/SERVER/src/data_handlers/LoginHandler.java
+++ b/SERVER/src/data_handlers/LoginHandler.java
@@ -135,16 +135,17 @@ public class LoginHandler extends Handler {
 		// SEND INFO ABOUT FAMILIES, CLASSES
 		if(message.startsWith("<newchar>")){
 
-			String newInfo = "1,Family Creatures";
+			StringBuilder newInfo = new StringBuilder(1000);
+			
+			newInfo.append("1,Family Creatures/");
 
 			// CreatureId, FamilyName; CreaureId2, FamilyName2 / ItemId; ItemId2
-
-			newInfo += "/";
 
 			ResultSet creatureInfo = Server.gameDB.askDB("select Id, Name, ClassId from creature where PlayerCreature = 1 and FamilyId = 1 and Level = 1");
 			try {
 				while(creatureInfo.next()){
-					newInfo += creatureInfo.getString("Id")+","+creatureInfo.getString("Name")+";";
+					newInfo.append(creatureInfo.getString("Id")).append(',')
+								 .append(creatureInfo.getString("Name")).append(';');
 				}
 				creatureInfo.close();
 			} catch (SQLException e) {
@@ -152,7 +153,7 @@ public class LoginHandler extends Handler {
 			}	
 
 
-			addOutGoingMessage(client,"newchar",newInfo);
+			addOutGoingMessage(client,"newchar",newInfo.toString());
 		}
 
 
@@ -190,7 +191,7 @@ public class LoginHandler extends Handler {
 				int charId = createCharacter(client,charName,creatureId, classId);
 
 				if(charId > 0){
-					addOutGoingMessage(client,"createchar",""+charId);
+					addOutGoingMessage(client,"createchar",String.valueOf(charId));
 				}else if(charId == 0){
 					addOutGoingMessage(client,"createchar","exists");
 				}else if(charId < 0){

--- a/SERVER/src/data_handlers/MapHandler.java
+++ b/SERVER/src/data_handlers/MapHandler.java
@@ -135,19 +135,17 @@ public class MapHandler extends Handler {
 			addOutGoingMessage(client,"canwalk",client.playerCharacter.getX()+","+client.playerCharacter.getY()+","+client.playerCharacter.getZ()+","+client.playerCharacter.getStat("SPEED"));
 
 			// Gather tile data
-			String screenData = "";
+			StringBuilder screenData = new StringBuilder(1000);
 
 			for(int j = client.playerCharacter.getY() - ServerSettings.TILE_HALF_H - 1; j < client.playerCharacter.getY() + ServerSettings.TILE_HALF_H+2; j++){
 				for(int i = client.playerCharacter.getX() - ServerSettings.TILE_HALF_W - 1; i < client.playerCharacter.getX() + ServerSettings.TILE_HALF_W+2; i++){
 
-					String tileInfo = getTileInfo(client, i, j, z, tileData);
-
-					screenData += tileInfo;
+					getTileInfo(client, i, j, z, tileData, screenData);
 				}
 			}
 
 			// Send tile data
-			addOutGoingMessage(client, "screen", screenData);
+			addOutGoingMessage(client, "screen", screenData.toString());
 
 			// Send info about soul if found
 			if(tileData.foundSoul){
@@ -175,7 +173,7 @@ public class MapHandler extends Handler {
 	 * @param tileData - additional info about the whole screen of tiles
 	 * @return
 	 */
-	public static String getTileInfo(Client client, int tileX, int tileY, int tileZ, TileData tileData){
+	public static void getTileInfo(Client client, int tileX, int tileY, int tileZ, TileData tileData, StringBuilder buf){
 
 		Tile TILE = Server.WORLD_MAP.getTile(tileX,tileY,tileZ);
 
@@ -259,7 +257,16 @@ public class MapHandler extends Handler {
 			}
 		}
 		
-		return tileX+","+tileY+","+tileZ+","+tileType+","+tileName+","+passable+","+lootInfo+","+objectInfo+","+statusEffects+":"+occupantInfo+";";
+		buf.append(tileX).append(',')
+		   .append(tileY).append(',')
+		   .append(tileZ).append(',')
+		   .append(tileType).append(',')
+		   .append(tileName).append(',')
+		   .append(passable).append(',')
+		   .append(lootInfo).append(',')
+		   .append(objectInfo).append(',')
+		   .append(statusEffects).append(':')
+		   .append(occupantInfo).append(';');
 	}
 
 	public static void checkIfDoorOpens(int MonsterDBId){

--- a/SERVER/src/data_handlers/Message.java
+++ b/SERVER/src/data_handlers/Message.java
@@ -3,33 +3,13 @@ package data_handlers;
 import network.Client;
 
 public class Message {
-	private Client client;
-	private String type;
-	private String message;
+	public final Client client;
+	public final String type;
+	public final String message;
 	
 	public Message(Client reciever, String type, String message){
 		this.client = reciever;
 		this.type = type;
 		this.message = message;
 	}
-	
-	public Client getClient() {
-		return client;
-	}
-	public void setClient(Client client) {
-		this.client = client;
-	}
-	public String getType() {
-		return type;
-	}
-	public void setType(String type) {
-		this.type = type;
-	}
-	public String getMessage() {
-		return message;
-	}
-	public void setMessage(String message) {
-		this.message = message;
-	}
-	
 }

--- a/SERVER/src/data_handlers/QuestHandler.java
+++ b/SERVER/src/data_handlers/QuestHandler.java
@@ -73,14 +73,18 @@ public class QuestHandler extends Handler {
 			if(serverData.startsWith("<myquests>")){
 				ResultSet myQuestInfo = Server.userDB.askDB("select QuestId, Status from character_quest where CharacterId = "+client.playerCharacter.getDBId()+" and Status > 0 and Status < 3");
 
-				String questData = "";
+				StringBuilder questData = new StringBuilder(1000);
 
 				try {
 					while(myQuestInfo.next()){
 						ResultSet questInfo = Server.mapDB.askDB("select Name, Type, Level from quest where Id = "+myQuestInfo.getInt("QuestId"));
 
 						if(questInfo.next()){
-							questData += myQuestInfo.getInt("QuestId")+","+questInfo.getString("Name")+","+questInfo.getString("Type")+","+myQuestInfo.getString("Status")+","+questInfo.getInt("Level")+";";
+							questData.append(myQuestInfo.getInt("QuestId")).append(',')
+							         .append(questInfo.getString("Name")).append(',')
+							         .append(questInfo.getString("Type")).append(',')
+							         .append(myQuestInfo.getString("Status")).append(',')
+							         .append(questInfo.getInt("Level")).append(';');
 						}
 						questInfo.close();
 					}
@@ -89,10 +93,10 @@ public class QuestHandler extends Handler {
 					e.printStackTrace();
 				}
 
-				if(questData.equals("")){
-					questData = "None";
+				if(questData.length() == 0){
+					questData.append("None");
 				}
-				addOutGoingMessage(client, "myquests", questData);
+				addOutGoingMessage(client, "myquests", questData.toString());
 			}
 
 
@@ -143,7 +147,11 @@ public class QuestHandler extends Handler {
 
 				// NpcName / QuestId, QuestName, QuestStatus; QuestId2, QuestName2, QuestStatus2 / ShopOrNot
 
-				String npcInfo = NPC.getDBId()+";"+NPC.getX()+";"+NPC.getY()+";"+NPC.getName()+"/";
+				StringBuilder npcInfo = new StringBuilder(1000);
+				npcInfo.append(NPC.getDBId()).append(';')
+				       .append(NPC.getX()).append(';')
+				       .append(NPC.getY()).append(';')
+				       .append(NPC.getName()).append('/');
 
 				// GET QUESTS FROM NPC
 				ResultSet rs = Server.mapDB.askDB("select Id, Name, Type, ParentQuestId, Level from quest where NpcId = "+NPC.getDBId()+" order by OrderNr asc");
@@ -183,7 +191,12 @@ public class QuestHandler extends Handler {
 
 						if(showOk){
 							// SEND QUEST IF NOT COMPLETED
-							npcInfo += rs.getInt("Id")+","+rs.getString("Name")+","+rs.getString("Type")+","+rs.getInt("Level")+","+questStatus+";";
+							
+							npcInfo.append(rs.getInt("Id")).append(',')
+							       .append(rs.getString("Name")).append(',')
+							       .append(rs.getString("Type")).append(',')
+							       .append(rs.getInt("Level")).append(',')
+							       .append(questStatus).append(';');
 
 							nrQuests++;
 						}
@@ -191,10 +204,8 @@ public class QuestHandler extends Handler {
 					rs.close();
 
 					if(nrQuests == 0){
-						npcInfo +="None";
+						npcInfo.append("None");
 					}
-
-					npcInfo += "/";
 
 					// GET SHOP FROM NPC
 
@@ -207,9 +218,7 @@ public class QuestHandler extends Handler {
 					}
 					rs.close();
 
-					npcInfo += shopId;
-
-					npcInfo += "/";
+					npcInfo.append('/').append(shopId);
 
 					// GET CHECKIN FROM NPC
 					int checkInId = 0;
@@ -221,12 +230,9 @@ public class QuestHandler extends Handler {
 					}
 					rs.close();
 
-					npcInfo += checkInId;
-
+					npcInfo.append('/').append(checkInId);
 
 					// GET BOUNTY MERCHANT
-
-					npcInfo += "/";
 
 					int bountyId = 0;
 /*
@@ -237,14 +243,14 @@ public class QuestHandler extends Handler {
 					}
 					rs.close();
 */
-					npcInfo += bountyId;
+					npcInfo.append('/').append(bountyId);
 
 
 				} catch (SQLException e) {
 					e.printStackTrace();
 				}
 
-				addOutGoingMessage(client,"talknpc",npcInfo);
+				addOutGoingMessage(client,"talknpc",npcInfo.toString());
 
 			}
 		}

--- a/SERVER/src/data_handlers/ShopHandler.java
+++ b/SERVER/src/data_handlers/ShopHandler.java
@@ -24,7 +24,7 @@ public class ShopHandler extends Handler {
 				int shopId = Integer.parseInt(message.substring(6));
 
 				String shopItemInfo = "None";
-				String shopAbilitiesInfo = "";
+				StringBuilder shopAbilitiesInfo = new StringBuilder();
 
 				// CHECK IF SHOP EXIST AND HAS ITEMS
 				boolean foundShop = false;
@@ -63,12 +63,14 @@ public class ShopHandler extends Handler {
 									if(abilityInfo.getInt("ClassId") > 0){
 										color = ServerGameInfo.classDef.get(abilityInfo.getInt("ClassId")).bgColor;
 									}
-									shopAbilitiesInfo += aId+","+color+","+abilityInfo.getInt("GraphicsNr")+":";
+									shopAbilitiesInfo.append(aId).append(',')
+									                 .append(color).append(',')
+									                 .append(abilityInfo.getInt("GraphicsNr")).append(':');
 								}
 								abilityInfo.close();
 							}
 						}else{
-							shopAbilitiesInfo = "None";
+							shopAbilitiesInfo.append("None");
 						}
 
 
@@ -80,7 +82,7 @@ public class ShopHandler extends Handler {
 				}
 
 				if(foundShop){
-					addOutGoingMessage(client,"shop",npcName+";"+shopItemInfo+";"+shopAbilitiesInfo);
+					addOutGoingMessage(client,"shop",npcName+";"+shopItemInfo+";"+shopAbilitiesInfo.toString());
 					InventoryHandler.sendInventoryInfo(client);
 				}
 			}
@@ -242,8 +244,13 @@ public class ShopHandler extends Handler {
 
 								Ability A = client.playerCharacter.getAbilityById(abilityId);
 								if(A != null){
-									String AbilityInfo = A.getAbilityId()+"="+A.getName()+"="+A.getClassId()+"="+A.getColor().getRed()+"="+A.getColor().getGreen()+"="+A.getColor().getBlue()+"="+A.getManaCost()+"="+A.getCooldown()+"="+A.getCooldownLeft()+"="+A.getRange()+"="+A.getPrice()+"="+A.isTargetSelf()+"="+A.isInstant()+"="+A.getEquipReq()+"="+A.getGraphicsNr()+"="+A.getAoE();
-									addOutGoingMessage(client,"buy","ability/"+A.getName()+"/"+shopAbility.getPrice()+"/"+AbilityInfo);
+									String msg = "ability/"+A.getName()+'/'+shopAbility.getPrice()+'/'
+									    +A.getAbilityId()+'='+A.getName()+'='+A.getClassId()+'='
+									    +A.getColor().getRed()+'='+A.getColor().getGreen()+'='+A.getColor().getBlue()
+									    +'='+A.getManaCost()+'='+A.getCooldown()+'='+A.getCooldownLeft()
+									    +'='+A.getRange()+'='+A.getPrice()+'='+A.isTargetSelf()+'='
+									    +A.isInstant()+'='+A.getEquipReq()+'='+A.getGraphicsNr()+'='+A.getAoE();
+									addOutGoingMessage(client,"buy",msg);
 								}
 							}else{
 								addOutGoingMessage(client,"shoperror","noreq");

--- a/SERVER/src/data_handlers/SkillHandler.java
+++ b/SERVER/src/data_handlers/SkillHandler.java
@@ -18,46 +18,71 @@ public class SkillHandler extends Handler {
 
 	public static void handleData(Client client, String message){
 		if(message.startsWith("<particledata>")){
-			String emitterData = "";
+			StringBuilder msg = new StringBuilder(1000);
 			ResultSet emitterInfo = Server.gameDB.askDB("select * from Emitter");
 			try {
 				while(emitterInfo.next()){
-					emitterData += emitterInfo.getInt("Id")+";"+emitterInfo.getString("Name")+";"+emitterInfo.getFloat("LifeTime")+";"+emitterInfo.getFloat("EmittionRate")+";"+emitterInfo.getFloat("RotationSpeed")+";"+emitterInfo.getString("MinPos")+";"+emitterInfo.getString("MaxPos")+";"+emitterInfo.getInt("ShowParticle")+";"+emitterInfo.getInt("ParticleId")+";"+emitterInfo.getInt("ShowStreak")+";"+emitterInfo.getInt("StreakId")+"/";
+					msg.append(emitterInfo.getInt("Id")).append(';')
+					   .append(emitterInfo.getString("Name")).append(';')
+					   .append(emitterInfo.getFloat("LifeTime")).append(';')
+					   .append(emitterInfo.getFloat("EmittionRate")).append(';')
+					   .append(emitterInfo.getFloat("RotationSpeed")).append(';')
+					   .append(emitterInfo.getString("MinPos")).append(';')
+					   .append(emitterInfo.getString("MaxPos")).append(';')
+					   .append(emitterInfo.getInt("ShowParticle")).append(';')
+					   .append(emitterInfo.getInt("ParticleId")).append(';')
+					   .append(emitterInfo.getInt("ShowStreak")).append(';')
+					   .append(emitterInfo.getInt("StreakId")).append('/');
 				}
 				emitterInfo.close();
 			} catch (SQLException e) {
 				e.printStackTrace();
 			}
-			String particleData = "%";
+			msg.append('%');
 			ResultSet particleInfo = Server.gameDB.askDB("select * from Particle");
 			try {
 				while(particleInfo.next()){
-					particleData += particleInfo.getInt("Id")+";"+particleInfo.getString("Name")+";"+particleInfo.getString("MinDir")+";";
-					particleData += particleInfo.getString("MaxDir")+";"+particleInfo.getInt("MinAxisRotSpeed")+";"+particleInfo.getInt("MaxAxisRotSpeed")+";";
-					particleData += particleInfo.getFloat("MinScale")+";"+particleInfo.getFloat("MaxScale")+";"+particleInfo.getFloat("LifeTime")+";";
-					particleData += particleInfo.getString("ImageString")+";"+particleInfo.getFloat("VerticalGravity")+";"+particleInfo.getFloat("HorizontalGravity")+";";
-					particleData += particleInfo.getString("StartColor")+";"+particleInfo.getString("EndColor")+";"+particleInfo.getFloat("RotationSpeed")+";"+particleInfo.getFloat("FadeSpeed")+"/";
+					msg.append(particleInfo.getInt("Id")).append(';')
+					   .append(particleInfo.getString("Name")).append(';')
+					   .append(particleInfo.getString("MinDir")).append(';')
+					   .append(particleInfo.getString("MaxDir")).append(';')
+					   .append(particleInfo.getInt("MinAxisRotSpeed")).append(';')
+					   .append(particleInfo.getInt("MaxAxisRotSpeed")).append(';')
+					   .append(particleInfo.getFloat("MinScale")).append(';')
+					   .append(particleInfo.getFloat("MaxScale")).append(';')
+					   .append(particleInfo.getFloat("LifeTime")).append(';')
+					   .append(particleInfo.getString("ImageString")).append(';')
+					   .append(particleInfo.getFloat("VerticalGravity")).append(';')
+					   .append(particleInfo.getFloat("HorizontalGravity")).append(';')
+					   .append(particleInfo.getString("StartColor")).append(';')
+					   .append(particleInfo.getString("EndColor")).append(';')
+					   .append(particleInfo.getFloat("RotationSpeed")).append(';')
+					   .append(particleInfo.getFloat("FadeSpeed")).append('/');
 				}
 				particleInfo.close();
 			} catch (SQLException e) {
 				e.printStackTrace();
 			}
-			String projectileData = "%";
+			msg.append('%');
 			ResultSet projectileInfo = Server.gameDB.askDB("select * from projectile");
 			try {
 				while(projectileInfo.next()){
-					projectileData += projectileInfo.getInt("Id")+";"+projectileInfo.getString("GfxName")+";"+projectileInfo.getInt("EmitterId")+";"+projectileInfo.getString("HitColor")+";"+projectileInfo.getString("Sfx")+"/";
+					msg.append(projectileInfo.getInt("Id")).append(';')
+					   .append(projectileInfo.getString("GfxName")).append(';')
+					   .append(projectileInfo.getInt("EmitterId")).append(';')
+					   .append(projectileInfo.getString("HitColor")).append(';')
+					   .append(projectileInfo.getString("Sfx")).append('/');
 				}
 				projectileInfo.close();
 			} catch (SQLException e) {
 				e.printStackTrace();
 			}
 
-			addOutGoingMessage(client,"particledata",emitterData+particleData+projectileData);
+			addOutGoingMessage(client,"particledata",msg.toString());
 
 		}else if(message.startsWith("<skilldata>")){
 			if(client.playerCharacter != null){
-				String skillData = "";
+				StringBuilder skillData = new StringBuilder(1000);
 
 				// GET SKILL INFO
 				ResultSet skillInfo = Server.userDB.askDB("select SkillId, Level, SP from character_skill where CharacterId = "+client.playerCharacter.getDBId()+" order by SkillId asc");
@@ -72,7 +97,11 @@ public class SkillHandler extends Handler {
 				
 						if(skillDef != null){
 							nextSP = XPTables.nextLevelSP.get(skillInfo.getInt("Level") + 1);
-							skillData += skillInfo.getInt("SkillId")+","+skillDef.getName()+","+skillInfo.getInt("Level")+","+skillInfo.getInt("SP")+","+nextSP+";";	
+							skillData.append(skillInfo.getInt("SkillId")).append(',')
+					   .append(skillDef.getName()).append(',')
+					   .append(skillInfo.getInt("Level")).append(',')
+					   .append(skillInfo.getInt("SP")).append(',')
+					   .append(nextSP).append(';');
 						}
 						
 					}
@@ -80,7 +109,7 @@ public class SkillHandler extends Handler {
 				} catch (SQLException e) {
 					e.printStackTrace();
 				}
-				addOutGoingMessage(client,"skilldata",skillData);
+				addOutGoingMessage(client,"skilldata",skillData.toString());
 			}
 		}
 	}
@@ -103,9 +132,9 @@ public class SkillHandler extends Handler {
 					if(skill.addSP(sp)){
 						// skillName, skillLevel, SP, SPnext
 						int nextSP = XPTables.nextLevelSP.get(skill.getLevel()+1);
-						addOutGoingMessage(client, "sp_levelup", skill.getName()+","+skill.getLevel()+","+skill.getSP()+","+nextSP);
+						addOutGoingMessage(client, "sp_levelup", skill.getName()+','+skill.getLevel()+','+skill.getSP()+','+nextSP);
 					}else {
-						addOutGoingMessage(client,"set_sp",skill.getId()+","+skill.getSP());	
+						addOutGoingMessage(client,"set_sp",skill.getId()+","+skill.getSP());
 					}	
 
 					Server.userDB.updateDB("update character_skill set SP = "+skill.getSP()+", Level = "+skill.getLevel()+" where CharacterId = "+client.playerCharacter.getDBId()+" and SkillId = "+skillId);
@@ -121,7 +150,7 @@ public class SkillHandler extends Handler {
 			if(skill.addSP(sp)){
 				// skillName, skillLevel, SP, SPnext
 				int nextSP = XPTables.nextLevelXP.get(skill.getLevel()+1);
-				addOutGoingMessage(client, "sp_levelup", skill.getName()+","+skill.getLevel()+","+skill.getSP()+","+nextSP);
+				addOutGoingMessage(client, "sp_levelup", skill.getName()+','+skill.getLevel()+','+skill.getSP()+','+nextSP);
 			}else {
 				addOutGoingMessage(client,"set_sp",skillId+","+skill.getSP());	
 			}	

--- a/SERVER/src/data_handlers/SkinHandler.java
+++ b/SERVER/src/data_handlers/SkinHandler.java
@@ -15,7 +15,7 @@ public class SkinHandler extends Handler {
 	}
 	
 	public static String getClosetContent(Client client){
-		String content = "";
+		StringBuilder content = new StringBuilder(1000);
 		
 		// GET CONTENT OF CLOSET
 		ResultSet closetInfo = Server.userDB.askDB("select ItemId from character_skin where SkinType = 'Item' and CharacterId = "+client.playerCharacter.getDBId());
@@ -23,13 +23,17 @@ public class SkinHandler extends Handler {
 		int sizeW = 5;
 		int sizeH = 7;
 		
-		content = "Closet"+","+sizeW+","+sizeH+"/";
+		content.append("Closet,")
+		       .append(sizeW).append(',')
+		       .append(sizeH).append('/');
 		
 		try {
 			while(closetInfo.next()){
 				Item skinItem = new Item(ServerGameInfo.itemDef.get(closetInfo.getInt("ItemId")));
 				
-				content += skinItem.getId()+","+skinItem.getName()+","+skinItem.getSubType()+";";				    
+				content.append(skinItem.getId()).append(',')
+				       .append(skinItem.getName()).append(',')
+				       .append(skinItem.getSubType()).append(';');
 			}
 			closetInfo.close();
 		} catch (SQLException e) {
@@ -37,13 +41,13 @@ public class SkinHandler extends Handler {
 			e.printStackTrace();
 		}
 		
-		content += "184,Remove,All;";
+		content.append("184,Remove,All;");
 		
-		return content;
+		return content.toString();
 	}
 	
 	public static String getCharacterSkins(Client client){
-		String skins = "";
+		StringBuilder skins = new StringBuilder(1000);
 		ResultSet closetInfo = Server.userDB.askDB("select ItemId from character_skin where CharacterId = "+client.playerCharacter.getDBId()+" and SkinType = 'Character'");
 		
 		try {
@@ -51,19 +55,20 @@ public class SkinHandler extends Handler {
 				ResultSet skinInfo = Server.gameDB.askDB("select Name from creature where Id = "+closetInfo.getInt("ItemId"));
 				
 				if(skinInfo.next()){
-					skins += closetInfo.getInt("ItemId")+","+skinInfo.getString("Name")+";";
+					skins.append(closetInfo.getInt("ItemId")).append(',')
+					     .append(skinInfo.getString("Name")).append(';');
 				}
 				skinInfo.close();
 			}
 			if(skins.length() > 0){
-				skins = skins.substring(0, skins.length()-1);
+				skins.setLength(skins.length() - 1);
 			}
 			closetInfo.close();
 		} catch (SQLException e) {
 			e.printStackTrace();
 		}
 		
-		return skins;
+		return skins.toString();
 	}
 	
 	public static void handleData(Client client, String message){

--- a/SERVER/src/data_handlers/WalkHandler.java
+++ b/SERVER/src/data_handlers/WalkHandler.java
@@ -298,7 +298,7 @@ public class WalkHandler extends Handler {
 		int dirX = 0;
 		int dirY = 0;
 
-		String tilesData = "";
+		StringBuilder rowData = new StringBuilder(1000);
 
 		int doorId = Server.WORLD_MAP.getTile(PlayerX,PlayerY,PlayerZ).getDoorId();
 
@@ -382,7 +382,7 @@ public class WalkHandler extends Handler {
 					tileX = client.playerCharacter.getX() - ServerSettings.TILE_HALF_W - i;
 
 					for(tileY = client.playerCharacter.getY() - ServerSettings.TILE_HALF_H-1; tileY <= client.playerCharacter.getY() + ServerSettings.TILE_HALF_H+1; tileY++){
-						tilesData += MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData);
+						MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData, rowData);
 					}
 					//client.playerCharacter.setGotoRotation(270);
 
@@ -391,7 +391,7 @@ public class WalkHandler extends Handler {
 					tileX = client.playerCharacter.getX() + ServerSettings.TILE_HALF_W + i;
 
 					for(tileY = client.playerCharacter.getY() - ServerSettings.TILE_HALF_H-1; tileY <= client.playerCharacter.getY() + ServerSettings.TILE_HALF_H+1; tileY++){
-						tilesData += MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData);
+						MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData, rowData);
 					}
 					//client.playerCharacter.setGotoRotation(90);
 				}
@@ -403,7 +403,7 @@ public class WalkHandler extends Handler {
 					tileY = client.playerCharacter.getY() + ServerSettings.TILE_HALF_H + i;
 
 					for(tileX = client.playerCharacter.getX() - ServerSettings.TILE_HALF_W-1; tileX <= client.playerCharacter.getX() + ServerSettings.TILE_HALF_W +1; tileX++){
-						tilesData += MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData);
+						MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData, rowData);
 					}
 					//client.playerCharacter.setGotoRotation(180);
 
@@ -412,13 +412,13 @@ public class WalkHandler extends Handler {
 					tileY = client.playerCharacter.getY() - ServerSettings.TILE_HALF_H - i;
 
 					for(tileX = client.playerCharacter.getX() - ServerSettings.TILE_HALF_W-1; tileX <= client.playerCharacter.getX() + ServerSettings.TILE_HALF_W +1; tileX++){
-						tilesData += MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData);
+						MapHandler.getTileInfo(client,tileX, tileY, tileZ, tileData, rowData);
 					}
 					//client.playerCharacter.setGotoRotation(0);
 				}
 			}
 
-			addOutGoingMessage(client,"tilerow",tilesData);
+			addOutGoingMessage(client,"tilerow", rowData.toString());
 
 			// SET NEW POSITION OF PLAYER
 			client.playerCharacter.walkTo(PlayerX, PlayerY, PlayerZ);

--- a/SERVER/src/data_handlers/ability_handler/AbilityHandler.java
+++ b/SERVER/src/data_handlers/ability_handler/AbilityHandler.java
@@ -137,35 +137,35 @@ public class AbilityHandler extends Handler {
 
 		if(ServerGameInfo.abilityDef.containsKey(abilityId)){
 			Ability abilityInfo = ServerGameInfo.abilityDef.get(abilityId);
-			String infoToSend = "255,234,116;"+abilityInfo.getName()+"/";
-
-			infoToSend += "0,0,0; /";
-
-			infoToSend += "255,255,255;"+abilityInfo.getDescription()+"/";
-
-			infoToSend += "0,0,0; /";
+			StringBuilder infoToSend = new StringBuilder(1000);
+			infoToSend.append(infoType)
+			          .append("#255,234,116;")
+			          .append(abilityInfo.getName())
+			          .append("/0,0,0; /255,255,255;")
+			          .append(abilityInfo.getDescription())
+			          .append("/0,0,0; /");
 
 			if(abilityInfo.getDamage() > 0){
-				infoToSend += TextFormater.formatInfo("Damage: "+abilityInfo.getDamage());
+				TextFormater.formatInfo(infoToSend, "Damage: "+abilityInfo.getDamage());
 			}
 
 			if(abilityInfo.getStatusEffects().size() > 0){
 
-				infoToSend += TextFormater.formatInfo("Status Effects: ");
+				TextFormater.formatInfo(infoToSend, "Status Effects: ");
 				for(StatusEffect se: abilityInfo.getStatusEffects()){
-					infoToSend += TextFormater.formatInfo(se.getName());
+					TextFormater.formatInfo(infoToSend, se.getName());
 				}
 			}
 
-			infoToSend += "0,0,0; /";
+			infoToSend.append("0,0,0; /");
 
 			if(abilityInfo.isInstant()){
-				infoToSend += TextFormater.formatInfo("Type: Instant");
+				TextFormater.formatInfo(infoToSend, "Type: Instant");
 			}else{
-				infoToSend += TextFormater.formatInfo("Type: Projectile");
+				TextFormater.formatInfo(infoToSend, "Type: Projectile");
 			}
 
-			infoToSend += "0,0,0; /";
+			infoToSend.append("0,0,0; /");
 
 			if(abilityInfo.getClassId() > 0){
 				if(ServerGameInfo.classDef.containsKey(abilityInfo.getClassId())){
@@ -176,12 +176,11 @@ public class AbilityHandler extends Handler {
 						hasClass = true;
 					}
 
-					infoToSend += TextFormater.formatConditionInfo("Req Class: "+ServerGameInfo.classDef.get(abilityInfo.getClassId()).name,hasClass);
-
+					TextFormater.formatConditionInfo(infoToSend, "Req Class: "+ServerGameInfo.classDef.get(abilityInfo.getClassId()).name,hasClass);
 
 					if(hasClass){
 						if(client.playerCharacter.getClassById(abilityInfo.getClassId()) != null){
-							infoToSend += TextFormater.formatReqInfo("Req Class Lvl: ", abilityInfo.getClassLevel(), client.playerCharacter.getClassById(abilityInfo.getClassId()).level);
+							TextFormater.formatReqInfo(infoToSend, "Req Class Lvl: ", abilityInfo.getClassLevel(), client.playerCharacter.getClassById(abilityInfo.getClassId()).level);
 						}
 					}
 				}
@@ -193,26 +192,24 @@ public class AbilityHandler extends Handler {
 					if(abilityInfo.getFamilyId() == client.playerCharacter.getFamilyId()){
 						hasFamily = true;
 					}
-					infoToSend += TextFormater.formatConditionInfo("Req Family: "+ServerGameInfo.familyDef.get(abilityInfo.getFamilyId()).getName(),hasFamily);
+					TextFormater.formatConditionInfo(infoToSend, "Req Family: "+ServerGameInfo.familyDef.get(abilityInfo.getFamilyId()).getName(),hasFamily);
 				}
 			}
 
-			infoToSend += "0,0,0; /";
+			infoToSend.append("0,0,0; /");
 
-			infoToSend += TextFormater.formatInfo("Mana cost: "+abilityInfo.getManaCost());
-			infoToSend += TextFormater.formatInfo("Cooldown: "+abilityInfo.getCooldown()+" sec");
+			TextFormater.formatInfo(infoToSend, "Mana cost: "+abilityInfo.getManaCost());
+			TextFormater.formatInfo(infoToSend, "Cooldown: "+abilityInfo.getCooldown()+" sec");
 
-			infoToSend += "0,0,0; /";
-
+			infoToSend.append("0,0,0; /");
 
 			if(infoType.equals("shop")){
-				infoToSend += "0,0,0; /";
+				infoToSend.append("0,0,0; /");
 				boolean canAfford = client.playerCharacter.hasCopper(abilityInfo.getPrice());
-				infoToSend += TextFormater.formatPriceInfo("Price: ",abilityInfo.getPrice(),canAfford);
+				TextFormater.formatPriceInfo(infoToSend, "Price: ",abilityInfo.getPrice(),canAfford);
 			}
 
-
-			addOutGoingMessage(client,"ability_info",infoType+"#"+infoToSend);
+			addOutGoingMessage(client,"ability_info",infoToSend.toString());
 		}
 	}
 	
@@ -353,7 +350,10 @@ public class AbilityHandler extends Handler {
 
 										if(s.Ready && isVisibleForPlayer(s.playerCharacter,client.playerCharacter.getX(),client.playerCharacter.getY(),client.playerCharacter.getZ())){
 
-											addOutGoingMessage(s,"use_ability",client.playerCharacter.getSmallData()+";"+ABILITY.getAbilityId()+","+ABILITY.getColor().getRed()+","+ABILITY.getColor().getGreen()+","+ABILITY.getColor().getBlue()+","+ABILITY.getGraphicsNr()+","+ABILITY.getAnimationId()+","+client.playerCharacter.getAttackSpeed());
+											addOutGoingMessage(s,"use_ability",
+													client.playerCharacter.getSmallData()+';'+ABILITY.getAbilityId()+','+ABILITY.getColor().getRed()+','
+													+ABILITY.getColor().getGreen()+','+ABILITY.getColor().getBlue()+','+ABILITY.getGraphicsNr()+','
+													+ABILITY.getAnimationId()+','+client.playerCharacter.getAttackSpeed());
 										}
 									}
 
@@ -384,7 +384,7 @@ public class AbilityHandler extends Handler {
 										
 										Server.WORLD_MAP.getTile(client.playerCharacter.getX(), client.playerCharacter.getY(), client.playerCharacter.getZ()).setOccupant(CreatureType.Player, client.playerCharacter);
 
-										addOutGoingMessage(client, "respawn", client.playerCharacter.getX()+","+client.playerCharacter.getY()+","+client.playerCharacter.getZ());
+										addOutGoingMessage(client, "respawn", client.playerCharacter.getX()+","+client.playerCharacter.getY()+','+client.playerCharacter.getZ());
 
 									}else{
 
@@ -468,7 +468,10 @@ public class AbilityHandler extends Handler {
 							Client s = entry.getValue();
 
 							if(s.Ready && isVisibleForPlayer(s.playerCharacter,MONSTER.getX(),MONSTER.getY(),MONSTER.getZ())){
-								addOutGoingMessage(s,"use_ability",MONSTER.getSmallData()+";"+ABILITY.getAbilityId()+","+ABILITY.getColor().getRed()+","+ABILITY.getColor().getGreen()+","+ABILITY.getColor().getBlue()+","+ABILITY.getGraphicsNr()+","+ABILITY.getAnimationId()+","+MONSTER.getAttackSpeed());
+								addOutGoingMessage(s,"use_ability",
+										MONSTER.getSmallData()+';'+ABILITY.getAbilityId()+','+ABILITY.getColor().getRed()+','
+										+ABILITY.getColor().getGreen()+','+ABILITY.getColor().getBlue()+','+ABILITY.getGraphicsNr()+','
+										+ABILITY.getAnimationId()+','+MONSTER.getAttackSpeed());
 							}
 						}
 
@@ -545,8 +548,8 @@ public class AbilityHandler extends Handler {
 				Client s = entry.getValue();
 
 				if(s.Ready && isVisibleForPlayer(s.playerCharacter , startX, startY, startZ)){
-					addOutGoingMessage(s,"projectile",ABILITY.getProjectileId()+","+startX+","+startY+","+startZ+","+newProjectile2.getGoalX()+","+newProjectile2.getGoalY()+","+ABILITY.getDelay()+",1,0");
-					addOutGoingMessage(s,"projectile",ABILITY.getProjectileId()+","+startX+","+startY+","+startZ+","+newProjectile3.getGoalX()+","+newProjectile3.getGoalY()+","+ABILITY.getDelay()+",1,0");
+					addOutGoingMessage(s,"projectile",ABILITY.getProjectileId()+","+startX+','+startY+','+startZ+','+newProjectile2.getGoalX()+','+newProjectile2.getGoalY()+','+ABILITY.getDelay()+",1,0");
+					addOutGoingMessage(s,"projectile",ABILITY.getProjectileId()+","+startX+','+startY+','+startZ+','+newProjectile3.getGoalX()+','+newProjectile3.getGoalY()+','+ABILITY.getDelay()+",1,0");
 				}
 			}
 
@@ -572,7 +575,7 @@ public class AbilityHandler extends Handler {
 					}
 				}
 				
-				addOutGoingMessage(s,"projectile",projectileId+","+startX+","+startY+","+startZ+","+goalX+","+goalY+","+ABILITY.getDelay()+","+speed+","+ABILITY.getProjectileEffectId());
+				addOutGoingMessage(s,"projectile",projectileId+","+startX+','+startY+','+startZ+','+goalX+','+goalY+','+ABILITY.getDelay()+','+speed+','+ABILITY.getProjectileEffectId());
 			}
 		}
 
@@ -714,7 +717,7 @@ public class AbilityHandler extends Handler {
 
 									if(s.Ready){
 										if(isVisibleForPlayer(s.playerCharacter,CASTER.getX(),CASTER.getY(),CASTER.getZ())){
-											addOutGoingMessage(s,"creature_goto",CASTER.getSmallData()+";"+gotoX+","+gotoY+","+speed);
+											addOutGoingMessage(s,"creature_goto",CASTER.getSmallData()+';'+gotoX+','+gotoY+','+speed);
 										}
 									}
 								}
@@ -830,7 +833,7 @@ public class AbilityHandler extends Handler {
 							Client s = entry.getValue();
 
 							if(s.Ready && isVisibleForPlayer(s.playerCharacter,CASTER.getX(),CASTER.getY(),CASTER.getZ())){
-								addOutGoingMessage(s,"creature_goto",CASTER.getSmallData()+";"+gotoX+","+gotoY+","+speed);
+								addOutGoingMessage(s,"creature_goto",CASTER.getSmallData()+';'+gotoX+','+gotoY+','+speed);
 							}
 						}
 
@@ -1037,8 +1040,8 @@ public class AbilityHandler extends Handler {
 
 							regainedHealth = s.playerCharacter.regainHealth(inSafeZone);
 
-							addOutGoingMessage(s, "stat", "HEALTH_REGAIN;"+s.playerCharacter.getStat("HEALTH_REGAIN")+";"+s.playerCharacter.getSatisfied());
-							addOutGoingMessage(s, "stat", "MANA_REGAIN;"+s.playerCharacter.getStat("MANA_REGAIN")+";"+s.playerCharacter.getSatisfied());
+							addOutGoingMessage(s, "stat", "HEALTH_REGAIN;"+s.playerCharacter.getStat("HEALTH_REGAIN")+';'+s.playerCharacter.getSatisfied());
+							addOutGoingMessage(s, "stat", "MANA_REGAIN;"+s.playerCharacter.getStat("MANA_REGAIN")+';'+s.playerCharacter.getSatisfied());
 						}
 
 						if(regainedHealth != 0){
@@ -1049,7 +1052,7 @@ public class AbilityHandler extends Handler {
 									Client other = entry2.getValue();
 									if(other.Ready){
 										if(isVisibleForPlayer(other.playerCharacter,s.playerCharacter.getX(),s.playerCharacter.getY(), s.playerCharacter.getZ())){
-											addOutGoingMessage(other,"changehealthstatus",s.playerCharacter.getSmallData()+";"+s.playerCharacter.getHealthStatus());
+											addOutGoingMessage(other,"changehealthstatus",s.playerCharacter.getSmallData()+';'+s.playerCharacter.getHealthStatus());
 										}
 									}
 								}
@@ -1059,7 +1062,7 @@ public class AbilityHandler extends Handler {
 						// UPDATE COOLDOWNS
 						for(Ability a:s.playerCharacter.getAbilities()){
 							if(a.checkReady()){
-								addOutGoingMessage(s,"ability_ready",""+a.getAbilityId());
+								addOutGoingMessage(s,"ability_ready",String.valueOf(a.getAbilityId()));
 							}
 						}						
 					}

--- a/SERVER/src/data_handlers/battle_handler/HitHandler.java
+++ b/SERVER/src/data_handlers/battle_handler/HitHandler.java
@@ -194,10 +194,10 @@ public class HitHandler extends Handler {
 	
 					if(other.Ready && Handler.isVisibleForPlayer(other.playerCharacter, TARGET.getX(), TARGET.getY(),TARGET.getZ())){
 						// Send health status
-						addOutGoingMessage(other, "changehealthstatus",TARGET.getSmallData()+";"+TARGET.getHealthStatus());
+						addOutGoingMessage(other, "changehealthstatus",TARGET.getSmallData()+';'+TARGET.getHealthStatus());
 						
 						if(removeManaShield){
-							addOutGoingMessage(other, "statuseffect_remove", TARGET.getSmallData()+";"+25);
+							addOutGoingMessage(other, "statuseffect_remove", TARGET.getSmallData()+";25");
 						}
 						if(TARGET.getCreatureType() == CreatureType.Player && other.playerCharacter.getDBId() == TARGET.getDBId()){
 							addOutGoingMessage(other,"update_bonusstats",TARGET.getBonusStatsAsString());
@@ -252,7 +252,7 @@ public class HitHandler extends Handler {
 	 
 			if (s.Ready) {
 				if(isVisibleForPlayer(s.playerCharacter,TARGET.getX(),TARGET.getY(),TARGET.getZ())){
-					addOutGoingMessage(s,"creature_hit",TARGET.getSmallData()+";"+damage+","+damageType+","+criticalOrMiss);
+					addOutGoingMessage(s,"creature_hit",TARGET.getSmallData()+';'+damage+','+damageType+','+criticalOrMiss);
 				}
 				
 				// Send updated health to target player

--- a/SERVER/src/data_handlers/item_handler/ItemHandler.java
+++ b/SERVER/src/data_handlers/item_handler/ItemHandler.java
@@ -73,10 +73,10 @@ public class ItemHandler extends Handler {
 				}else if(infoType.equals("closet")){
 					int itemId = Integer.parseInt(info[1]);
 					if(itemId == 214){
-						infoToSend = "255,234,116;"+"#ui.web.get_more_skins"+"/";
-						infoToSend += "0,0,0; /";
-						infoToSend += "255,255,255;"+"#ui.web.wide_selection"+"/";
-						infoToSend += "255,255,255;"+"#ui.web.customize"+"/";
+						infoToSend = "255,234,116;"+"#ui.web.get_more_skins"+"/"
+						           + "0,0,0; /"
+						           + "255,255,255;"+"#ui.web.wide_selection"+"/"
+						           + "255,255,255;"+"#ui.web.customize"+"/";
 					}else{
 						infoItem = new Item(ServerGameInfo.itemDef.get(itemId));
 					}
@@ -93,10 +93,10 @@ public class ItemHandler extends Handler {
 					userItemId = Integer.parseInt(info[1]);
 
 					if(userItemId == 0){
-						infoToSend = "255,234,116;"+"#ui.web.get_more_space"+"/";
-						infoToSend += "0,0,0; /";
-						infoToSend += "255,255,255;"+"#ui.web.expand_chest"+"/";
-						infoToSend += "255,255,255;"+"#ui.web.keep_safe"+"/";
+						infoToSend = "255,234,116;"+"#ui.web.get_more_space"+"/"
+						           + "0,0,0; /"
+						           + "255,255,255;"+"#ui.web.expand_chest"+"/"
+						           + "255,255,255;"+"#ui.web.keep_safe"+"/";
 					}else{
 						ResultSet userItemInfo = Server.userDB.askDB("select ItemId, ModifierId, MagicId from user_chest where Id = "+userItemId);
 
@@ -137,11 +137,13 @@ public class ItemHandler extends Handler {
 					}
 					
 				}
-								
+				
+				StringBuilder sb = new StringBuilder(1000);
+				sb.append(infoType)
+					.append('@')
+					.append(infoToSend);
 
 				if(infoItem != null){
-					
-					
 					if(infoItem.getMagicId() > 0){
 						String magicName = "0";
 						String magicColor = "0";
@@ -157,107 +159,108 @@ public class ItemHandler extends Handler {
 							e.printStackTrace();
 						}
 					
-						infoToSend = magicColor+";"+magicName+"/";
+						infoToSend = magicColor+';'+magicName+'/';
 					}
 					
-					infoToSend += infoItem.getColor()+";"+infoItem.getName()+"/";
+					sb.append(infoItem.getColor()).append(';')
+					  .append(infoItem.getName()).append('/')
 
-					infoToSend += "0,0,0; /";
-
-					infoToSend += "255,234,116;"+infoItem.getType()+" - "+infoItem.getSubType()+"/";
+					  .append("0,0,0; /255,234,116;")
+					  .append(infoItem.getType())
+					  .append(" - ")
+					  .append(infoItem.getSubType()).append('/');
 					if(infoItem.isTwoHands()){
-						infoToSend += TextFormater.formatInfo("Two Hands");
-					}					
+						TextFormater.formatInfo(sb, "Two Hands");
+					}
 
-					infoToSend += "0,0,0; /";
+					sb.append("0,0,0; /");
 
 					if(infoItem.getStatValue("MinDamage") > 0 || infoItem.getStatValue("MaxDamage") > 0){
-						infoToSend += TextFormater.formatInfo("Base DMG: "+infoItem.getStatValue("MinDamage")+" - "+infoItem.getStatValue("MaxDamage"));
+						TextFormater.formatInfo(sb, "Base DMG: "+infoItem.getStatValue("MinDamage")+" - "+infoItem.getStatValue("MaxDamage"));
 					}
 
-					infoToSend += TextFormater.formatStatInfo("ARMOR: ",infoItem.getStatValue("ARMOR"));
-					infoToSend += TextFormater.formatStatInfo("Fire DEF: ",infoItem.getStatValue("FIRE_DEF"));
-					infoToSend += TextFormater.formatStatInfo("Cold DEF: ",infoItem.getStatValue("COLD_DEF"));
-					infoToSend += TextFormater.formatStatInfo("Shock DEF: ",infoItem.getStatValue("SHOCK_DEF"));
-					infoToSend += TextFormater.formatStatInfo("Chems DEF: ",infoItem.getStatValue("CHEMS_DEF"));
-					infoToSend += TextFormater.formatStatInfo("Mind DEF: ",infoItem.getStatValue("MIND_DEF"));
+					TextFormater.formatStatInfo(sb, "ARMOR: ",infoItem.getStatValue("ARMOR"));
+					TextFormater.formatStatInfo(sb, "Fire DEF: ",infoItem.getStatValue("FIRE_DEF"));
+					TextFormater.formatStatInfo(sb, "Cold DEF: ",infoItem.getStatValue("COLD_DEF"));
+					TextFormater.formatStatInfo(sb, "Shock DEF: ",infoItem.getStatValue("SHOCK_DEF"));
+					TextFormater.formatStatInfo(sb, "Chems DEF: ",infoItem.getStatValue("CHEMS_DEF"));
+					TextFormater.formatStatInfo(sb, "Mind DEF: ",infoItem.getStatValue("MIND_DEF"));
 
-					infoToSend += "0,0,0; /";
+					sb.append("0,0,0; /");
 
-					infoToSend += TextFormater.formatBonusInfo("STR: ",infoItem.getStatValue("STRENGTH"));
-					infoToSend += TextFormater.formatBonusInfo("INT: ",infoItem.getStatValue("INTELLIGENCE"));
-					infoToSend += TextFormater.formatBonusInfo("AGI: ",infoItem.getStatValue("AGILITY"));
+					TextFormater.formatBonusInfo(sb, "STR: ",infoItem.getStatValue("STRENGTH"));
+					TextFormater.formatBonusInfo(sb, "INT: ",infoItem.getStatValue("INTELLIGENCE"));
+					TextFormater.formatBonusInfo(sb, "AGI: ",infoItem.getStatValue("AGILITY"));
 					
-					infoToSend += TextFormater.formatBonusInfo("SPD: ",infoItem.getStatValue("SPEED"));
-					infoToSend += TextFormater.formatBonusInfo("ATK SPD: ",infoItem.getStatValue("ATTACKSPEED"));
-					infoToSend += TextFormater.formatBonusInfo("CRIT HIT: ",infoItem.getStatValue("CRITICAL_HIT"));
-					infoToSend += TextFormater.formatBonusInfo("ACC: ",infoItem.getStatValue("ACCURACY"));
+					TextFormater.formatBonusInfo(sb, "SPD: ",infoItem.getStatValue("SPEED"));
+					TextFormater.formatBonusInfo(sb, "ATK SPD: ",infoItem.getStatValue("ATTACKSPEED"));
+					TextFormater.formatBonusInfo(sb, "CRIT HIT: ",infoItem.getStatValue("CRITICAL_HIT"));
+					TextFormater.formatBonusInfo(sb, "ACC: ",infoItem.getStatValue("ACCURACY"));
 					
 					
 					if(infoItem.getType().equals("Potion")){
-						infoToSend += TextFormater.formatBonusInfo("Restores Health: ",infoItem.getStatValue("MAX_HEALTH"));
-						infoToSend += TextFormater.formatBonusInfo("Restores Mana: ",infoItem.getStatValue("MAX_MANA"));
-						infoToSend += TextFormater.formatInfo("Instant effect");
+						TextFormater.formatBonusInfo(sb, "Restores Health: ",infoItem.getStatValue("MAX_HEALTH"));
+						TextFormater.formatBonusInfo(sb, "Restores Mana: ",infoItem.getStatValue("MAX_MANA"));
+						TextFormater.formatInfo(sb, "Instant effect");
 					}else if(infoItem.getType().equals("Eatable")){
-						infoToSend += TextFormater.formatBonusInfo("Regain health: ",infoItem.getStatValue("MAX_HEALTH"));
-						infoToSend += TextFormater.formatBonusInfo("Regain mana: ",infoItem.getStatValue("MAX_MANA"));
-						infoToSend += TextFormater.formatInfo("Regain over time,");
-						infoToSend += TextFormater.formatInfo("sleep for faster effect");
+						TextFormater.formatBonusInfo(sb, "Regain health: ",infoItem.getStatValue("MAX_HEALTH"));
+						TextFormater.formatBonusInfo(sb, "Regain mana: ",infoItem.getStatValue("MAX_MANA"));
+						TextFormater.formatInfo(sb, "Regain over time,");
+						TextFormater.formatInfo(sb, "sleep for faster effect");
 					}else{
-						infoToSend += TextFormater.formatBonusInfo("MAX HEALTH: ",infoItem.getStatValue("MAX_HEALTH"));
-						infoToSend += TextFormater.formatBonusInfo("MAX MANA: ",infoItem.getStatValue("MAX_MANA"));
+						TextFormater.formatBonusInfo(sb, "MAX HEALTH: ",infoItem.getStatValue("MAX_HEALTH"));
+						TextFormater.formatBonusInfo(sb, "MAX MANA: ",infoItem.getStatValue("MAX_MANA"));
 					}
 					
-					infoToSend += "0,0,0; /";
+					sb.append("0,0,0; /");
 
-					
-					infoToSend += TextFormater.formatReqInfo("Req STR: ",infoItem.getRequirement("ReqStrength"),client.playerCharacter.getStat("STRENGTH"));
-					infoToSend += TextFormater.formatReqInfo("Req INT: ",infoItem.getRequirement("ReqIntelligence"),client.playerCharacter.getStat("INTELLIGENCE"));
-					infoToSend += TextFormater.formatReqInfo("Req AGI: ",infoItem.getRequirement("ReqAgility"),client.playerCharacter.getStat("AGILITY"));
-					infoToSend += TextFormater.formatReqInfo("Req LVL: ",infoItem.getRequirement("ReqLevel"),client.playerCharacter.getLevel());
+					TextFormater.formatReqInfo(sb, "Req STR: ",infoItem.getRequirement("ReqStrength"),client.playerCharacter.getStat("STRENGTH"));
+					TextFormater.formatReqInfo(sb, "Req INT: ",infoItem.getRequirement("ReqIntelligence"),client.playerCharacter.getStat("INTELLIGENCE"));
+					TextFormater.formatReqInfo(sb, "Req AGI: ",infoItem.getRequirement("ReqAgility"),client.playerCharacter.getStat("AGILITY"));
+					TextFormater.formatReqInfo(sb, "Req LVL: ",infoItem.getRequirement("ReqLevel"),client.playerCharacter.getLevel());
 					if(infoItem.getClassId() > 0){
-						infoToSend += TextFormater.formatConditionInfo("Req Class: "+ServerGameInfo.classDef.get(infoItem.getClassId()).name,client.playerCharacter.hasClass(infoItem.getClassId()));
+						TextFormater.formatConditionInfo(sb, "Req Class: "+ServerGameInfo.classDef.get(infoItem.getClassId()).name,client.playerCharacter.hasClass(infoItem.getClassId()));
 					}
 
 					if(infoType.equals("inv") && infoItem.getType().equals("Readable")){
-						infoToSend += "255,255,255;"+"#ui.inventory.right_click_to_use"+"/";
+						sb.append("255,255,255;#ui.inventory.right_click_to_use/");
 					}
 					if(infoType.equals("inv") && infoItem.getType().equals("Eatable")){
-						infoToSend += "255,255,255;"+"#ui.inventory.right_click_to_eat"+"/";
+						sb.append("255,255,255;#ui.inventory.right_click_to_eat/");
 					}
 					if(infoType.equals("inv") && infoItem.getType().equals("Potion")){
-						infoToSend += "255,255,255;"+"#ui.inventory.right_click_to_use"+"/";
+						sb.append("255,255,255;#ui.inventory.right_click_to_use/");
 					}
 
 					if(infoType.equals("shop")){
-						infoToSend += "0,0,0; /";
+						sb.append("0,0,0; /");
 						boolean canAfford = client.playerCharacter.hasCopper(infoItem.getValue());
 						if(infoItem.getValue() > 0){
-							infoToSend += TextFormater.formatPriceInfo("Price: ",infoItem.getValue(),canAfford);
+							TextFormater.formatPriceInfo(sb, "Price: ",infoItem.getValue(),canAfford);
 						}else{
-							infoToSend += TextFormater.formatInfo("Free");
+							TextFormater.formatInfo(sb, "Free");
 						}
 					}
 
 					if(infoType.equals("invshop")){
-						infoToSend += "0,0,0; /";
+						sb.append("0,0,0; /");
 						int price = infoItem.getValue();
 
 						if(!infoItem.getType().equals("Money")){
 							price = infoItem.getSoldValue();
 						}
 						if(!infoItem.isSellable()){
-							infoToSend += TextFormater.formatInfo("Can't be sold");
+							TextFormater.formatInfo(sb, "Can't be sold");
 						}else {
-							infoToSend += TextFormater.formatValueInfo("#ui.shop.sell_value#: ",price);
-							infoToSend += TextFormater.formatInfo("#ui.shop.right_click_sell");
+							TextFormater.formatValueInfo(sb, "#ui.shop.sell_value#: ",price);
+							TextFormater.formatInfo(sb, "#ui.shop.right_click_sell");
 						}
 					}
 
 				}
 
-				if(infoToSend != ""){
-					addOutGoingMessage(client,"item_info",infoType+"@"+infoToSend);
+				if(sb.length()!=0){
+					addOutGoingMessage(client,"item_info",sb.toString());
 				}
 			}
 
@@ -376,8 +379,8 @@ public class ItemHandler extends Handler {
 					// SEND STATSCHANGE
 					if(usedItem.getType().equals("Eatable")){
 						useColor = new Color(202,253,161);
-						addOutGoingMessage(client, "stat", "HEALTH_REGAIN;"+client.playerCharacter.getStat("HEALTH_REGAIN")+";"+client.playerCharacter.getSatisfied());
-						addOutGoingMessage(client, "stat", "MANA_REGAIN;"+client.playerCharacter.getStat("MANA_REGAIN")+";"+client.playerCharacter.getSatisfied());
+						addOutGoingMessage(client, "stat", "HEALTH_REGAIN;"+client.playerCharacter.getStat("HEALTH_REGAIN")+';'+client.playerCharacter.getSatisfied());
+						addOutGoingMessage(client, "stat", "MANA_REGAIN;"+client.playerCharacter.getStat("MANA_REGAIN")+';'+client.playerCharacter.getSatisfied());
 					}else if(usedItem.getSubType().equals("HEALTH")){
 						useColor = new Color(255,88,88);
 					}else if(usedItem.getSubType().equals("MANA")){
@@ -390,7 +393,7 @@ public class ItemHandler extends Handler {
 
 						if(s.Ready && isVisibleForPlayer(s.playerCharacter,client.playerCharacter.getX(),client.playerCharacter.getY(),client.playerCharacter.getZ())){
 							// UserType; UserId; R; G; B
-							addOutGoingMessage(s,"useitem",client.playerCharacter.getSmallData()+";"+useColor.getRed()+","+useColor.getGreen()+","+useColor.getBlue()+","+client.playerCharacter.getHealthStatus()+";"+usedItem.getType()+","+usedItem.getSubType());
+							addOutGoingMessage(s,"useitem",client.playerCharacter.getSmallData()+';'+useColor.getRed()+','+useColor.getGreen()+','+useColor.getBlue()+','+client.playerCharacter.getHealthStatus()+';'+usedItem.getType()+','+usedItem.getSubType());
 						}
 					}
 				}else{

--- a/SERVER/src/utils/TextFormater.java
+++ b/SERVER/src/utils/TextFormater.java
@@ -2,84 +2,66 @@ package utils;
 
 public class TextFormater {
 
-	
-	
-	public static String formatStatInfo(String label, int statValue){
-		String formatedInfo = "";
+	public static void formatStatInfo(StringBuilder sb, String label, int statValue){
 		if(statValue != 0){
 			if(statValue < 0){
-				formatedInfo += "190,60,60;";
+				sb.append("190,60,60;");
 			}else{
-				formatedInfo += "255,255,255;";
+				sb.append("255,255,255;");
 			}
-			
-			formatedInfo += label+statValue+"/";
+			sb.append(label).append(statValue).append('/');
 		}
-		return formatedInfo;
 	}
 
 	
-	public static String formatBonusInfo(String label, int statValue){
-		String formatedInfo = "";
+	public static void formatBonusInfo(StringBuilder sb, String label, int statValue){
 		if(statValue != 0){
 			if(statValue < 0){
-				formatedInfo += "190,60,60;";
-				formatedInfo += label+""+statValue+"/";
+				sb.append("190,60,60;")
+				  .append(label)
+				  .append(statValue).append('/');
 			}else{
-				formatedInfo += "0,180,0;";
-				formatedInfo += label+"+"+statValue+"/";
+				sb.append("0,180,0;")
+				  .append(label).append('+')
+				  .append(statValue).append('/');
 			}
 		}
-		return formatedInfo;
 	}
 	
-	public static String formatReqInfo(String label, int statValue, int characterValue){
-		String formatedInfo = "";
+	public static void formatReqInfo(StringBuilder sb, String label, int statValue, int characterValue){
 		if(statValue != 0){
 			if(statValue <= characterValue){
-				formatedInfo += "0,180,0;";
+				sb.append("0,180,0;");
 			}else{
-				formatedInfo += "190,60,60;";
+				sb.append("190,60,60;");
 			}
-			formatedInfo += label+statValue+"/";
+			sb.append(label).append(statValue).append('/');
 		}
-		return formatedInfo;
 	}
 
-	public static String formatConditionInfo(String label, boolean hasReq){
-		String formatedInfo = "";
-		if(!hasReq){
-			formatedInfo += "190,60,60;";
+	public static void formatConditionInfo(StringBuilder sb, String label, boolean hasReq){
+		if(hasReq){
+			sb.append("0,180,0;");
 		}else{
-			formatedInfo += "0,180,0;";
+			sb.append("190,60,60;");
 		}
-		formatedInfo += label+"/";
-		return formatedInfo;
+		sb.append(label).append('/');
 	}
 	
-	public static String formatValueInfo(String label, int value){
-		String formatedInfo = "";
-		formatedInfo += "255,234,116;";
-		formatedInfo += label+value+"c/";
-		return formatedInfo;
+	public static void formatValueInfo(StringBuilder sb, String label, int value){
+		sb.append("255,234,116;").append(label).append(value).append("c/");
 	}
 	
-	public static String formatPriceInfo(String label, int price, boolean canAfford){
-		String formatedInfo = "";
-			if(canAfford){
-				formatedInfo += "255,234,116;";
-			}else{
-				formatedInfo += "190,60,60;";
-			}
-			formatedInfo += label+price+"c/";
-		return formatedInfo;
+	public static void formatPriceInfo(StringBuilder sb, String label, int price, boolean canAfford){
+		if(canAfford){
+			sb.append("255,234,116;");
+		}else{
+			sb.append("190,60,60;");
+		}
+		sb.append(label).append(price).append("c/");
 	}
 	
-	public static String formatInfo(String label){
-		String formatedInfo = "";
-		formatedInfo += "255,255,255;";
-		formatedInfo += label+"/";
-		
-		return formatedInfo;
+	public static void formatInfo(StringBuilder sb, String label){
+		sb.append("255,255,255;").append(label).append('/');
 	}
 }


### PR DESCRIPTION
- avoid using += on string (a new string object is created each time, with buffer-realloc)
- use StringBuilder with enough init space when making a lot of concatenations
- a single string+string+string+... is OK because the compiler transforms it to a StringBuilder behind the scene
- Also made Message an immutable object for better JIT and GC.

This patch does not change the logic at all. It only changes the string concatenations for messages to reduce the memory allocation and number of objects created. This should improve the performance a little bit and reduce the GC pressure.

Please double-check that the message format is identical when reviewing this diff: I verified and ran the code, but I might have missed some.
