### PR TITLE
Fix chat characters ;'>

### DIFF
--- a/CLIENT/src/data_handlers/ChatHandler.java
+++ b/CLIENT/src/data_handlers/ChatHandler.java
@@ -17,7 +17,7 @@ public class ChatHandler extends Handler {
 	public static void handleData(String serverData){
 		// CHAT DATA
 		if(serverData.startsWith("<newchat>")){
-			String chatinfo[] = serverData.substring(9).split(";");
+			String chatinfo[] = serverData.substring(9).split(";",3);
 			String chatChannel = chatinfo[0].toLowerCase();
 			String sender = chatinfo[1];
 			

--- a/SERVER/src/data_handlers/chat_handler/ChatHandler.java
+++ b/SERVER/src/data_handlers/chat_handler/ChatHandler.java
@@ -79,7 +79,7 @@ public class ChatHandler extends Handler {
 		Client client = m.client;
 		boolean specialCommand = false;
 		
-		String chatInfo[] = m.message.split(";");
+		String chatInfo[] = m.message.split(";",2);
 		
 		if(chatInfo.length == 2){
 			String chatChannel = chatInfo[0].toLowerCase();

--- a/SERVER/src/network/Client.java
+++ b/SERVER/src/network/Client.java
@@ -93,7 +93,7 @@ public class Client implements Runnable {
 								int messageId = Obfuscator.illuminate(messageIdobf);
 								
 								
-								String messageInfo[] = message.substring(messageIndex).split(">");
+								String messageInfo[] = message.substring(messageIndex).split(">",2);
 								String messageType = messageInfo[0].substring(1);
 								String messageText = messageInfo[1];
 		


### PR DESCRIPTION
In chat, the following characters are causing problems:
1) characters ; and > are truncating the chat text for no good reason. It's a bug due to the network packet format.
2) character ' is removed. I can't imagine the reason for that. I just deleted this line removing this character.
