### PR TITLE
Optimize memory usage for map and Npcs

### DIFF
--- a/SERVER/run
+++ b/SERVER/run
@@ -3,4 +3,4 @@
 JARS=../JARS
 export CLASSPATH="./build/:$JARS/bs_user.jar:$JARS/grandcentral.jar:$JARS/jogg-0.0.7.jar:$JARS/jorbis-0.0.15.jar:$JARS/json_simple.jar:$JARS/lwjgl.jar:$JARS/natives-linux.jar:$JARS/slick.jar:$JARS/sqlitejdbc-v056.jar"
 
-java -Djava.library.path=$JARS game.BPserver $*
+java -server -XX:StringTableSize=100003 -Djava.library.path=$JARS game.BPserver $*

--- a/SERVER/src/creature/Creature.java
+++ b/SERVER/src/creature/Creature.java
@@ -7,9 +7,10 @@ package creature;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Vector;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.newdawn.slick.util.pathfinding.Mover;
@@ -28,6 +29,8 @@ import network.Server;
 
 public class Creature implements Mover {
 
+	private static final List<Ability> EMPTY_ABILITIES = new ArrayList(0);
+	
 	protected int dbId; // Id in area_creature table or in user_character
 	protected int CreatureId;
 	protected String Name;
@@ -123,7 +126,7 @@ public class Creature implements Mover {
 	
 	
 	protected HashMap<Integer, JobSkill> jobSkills = new HashMap<Integer, JobSkill>();
-	protected Vector<Ability> abilities = new Vector<Ability>(); 
+	protected List<Ability> abilities;
 	private int DeathAbilityId = 0;
 	
 	
@@ -218,37 +221,35 @@ public class Creature implements Mover {
 			    
 			    setDeathAbilityId(rs.getInt("DeathAbility"));
 			    
-			    abilities = new Vector<Ability>(); 
-				
 			    if(rs.getInt("Ability1") > 0){
 					Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(rs.getInt("Ability1")));
 					newAbility.setCaster(CreatureType.Monster, this);
-					abilities.add(newAbility);
+					addAbility(newAbility);
 				}
 				if(rs.getInt("Ability2") > 0){
 					Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(rs.getInt("Ability2")));
 					newAbility.setCaster(CreatureType.Monster, this);
-					abilities.add(newAbility);
+					addAbility(newAbility);
 				}
 				if(rs.getInt("Ability3") > 0){
 					Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(rs.getInt("Ability3")));
 					newAbility.setCaster(CreatureType.Monster, this);
-					abilities.add(newAbility);
+					addAbility(newAbility);
 				}
 				if(rs.getInt("Ability4") > 0){
 					Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(rs.getInt("Ability4")));
 					newAbility.setCaster(CreatureType.Monster, this);
-					abilities.add(newAbility);
+					addAbility(newAbility);
 				}
 				if(rs.getInt("Ability5") > 0){
 					Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(rs.getInt("Ability5")));
 					newAbility.setCaster(CreatureType.Monster, this);
-					abilities.add(newAbility);
+					addAbility(newAbility);
 				}
 				if(rs.getInt("Ability6") > 0){
 					Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(rs.getInt("Ability6")));
 					newAbility.setCaster(CreatureType.Monster, this);
-					abilities.add(newAbility);
+					addAbility(newAbility);
 				}
 				
 			    moveTimerEnd = Stats.getValue("SPEED") * 10;
@@ -268,7 +269,6 @@ public class Creature implements Mover {
 		} catch (SQLException e1) {
 			e1.printStackTrace();
 		}
-	    
 	}
 	
 	public Creature(Creature copy, int creatureX, int creatureY, int creatureZ){
@@ -321,11 +321,10 @@ public class Creature implements Mover {
 		}  
 	    
 		// Add abilities
-		abilities = new Vector<Ability>(); 
 		for(Ability ability: copy.getAbilities()){
 			Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(ability.getAbilityId()));
 			newAbility.setCaster(CreatureType.Monster, this);
-			abilities.add(newAbility);
+			addAbility(newAbility);
 		}
 		
 	    Health = Stats.getValue("MAX_HEALTH");
@@ -524,8 +523,8 @@ public class Creature implements Mover {
 	}
 	
 	
-	public Vector<Ability> getAbilities() {
-		return abilities;
+	public List<Ability> getAbilities() {
+		return (abilities!=null) ? abilities : EMPTY_ABILITIES;
 	}
 	
 	public int getNrAbilities() {
@@ -547,6 +546,9 @@ public class Creature implements Mover {
 	
 	
 	public void addAbility(Ability newAbility){
+		if (abilities==null) {
+			abilities = new ArrayList(1);
+		}
 		abilities.add(newAbility);
 	}
 	

--- a/SERVER/src/creature/Npc.java
+++ b/SERVER/src/creature/Npc.java
@@ -4,6 +4,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.ThreadLocalRandom;
@@ -75,7 +76,7 @@ public class Npc extends Creature {
 	private int SpawnZ;
 
 	private boolean usedStashItem = false;
-	private Vector<Item> StashItems;
+	private List<Item> StashItems;
 
 	private boolean BountyMonster = false;
 	private int Bounty = 0;
@@ -94,8 +95,6 @@ public class Npc extends Creature {
 	private boolean titan = false;
 	private boolean raging = false;
 	
-	private Vector<String> states = new Vector<String>();
-	
 	private final BaseAI ai;
 	
 	public Npc(int creatureId, int newX, int newY, int newZ) {
@@ -108,12 +107,10 @@ public class Npc extends Creature {
 		SpawnY = newY;
 		SpawnZ = newZ;
 
-		StashItems = new Vector<Item>();
+		StashItems = new ArrayList<Item>(3);
 
 		attackersDamage = new HashMap<Creature, Integer>();	
 
-		states.clear();
-		
 		ResultSet rs = Server.gameDB.askDB("select AggroRange,RespawnTime, MonsterWeaponIds, MonsterOffHandIds, MonsterHeadIds, GiveXP, Level from creature where Id = "+creatureId);
 		try {
 			if(rs.next()){
@@ -156,12 +153,10 @@ public class Npc extends Creature {
 		SpawnY = npcY;
 		SpawnZ = npcZ;
 
-		StashItems = new Vector<Item>();
+		StashItems = new ArrayList<Item>(3);
 
 		attackersDamage = new HashMap<Creature, Integer>();	
 
-		states.clear();
-		
 		setMonsterWeaponIds(copy.getMonsterWeaponIds());
 		setMonsterOffHandIds(copy.getMonsterOffHandIds());
 		setMonsterHeadIds(copy.getMonsterHeadIds());
@@ -388,15 +383,9 @@ public class Npc extends Creature {
 	}
 
 	public Ability useRandomAbility(){
-		ArrayList<Ability> ActiveAbilities = new ArrayList<Ability>(); 
-
-		for(int i = 0; i < abilities.size(); i++){
-			ActiveAbilities.add(abilities.get(i));
-		}
-
-		if(ActiveAbilities.size() > 0){
-			int random = ThreadLocalRandom.current().nextInt() % ActiveAbilities.size();
-			return ActiveAbilities.get(random);
+		if(abilities!=null && abilities.size()>0){
+			int random = ThreadLocalRandom.current().nextInt() % abilities.size();
+			return abilities.get(random);
 		}
 		return null;
 	}
@@ -531,12 +520,11 @@ public class Npc extends Creature {
 	    Health = Stats.getValue("MAX_HEALTH");
 	    Mana = Stats.getValue("MAX_MANA");
 	
-	    abilities = new Vector<Ability>(); 
-		
+	    abilities = null;
 	    for(Ability a: original_monster.getAbilities()){
 	    	Ability newAbility = new Ability(ServerGameInfo.abilityDef.get(a.getAbilityId()));
 			newAbility.setCaster(CreatureType.Monster, this);
-			abilities.add(newAbility);
+			addAbility(newAbility);
 	    }
 	    
 	    Level = original_monster.getLevel();
@@ -864,7 +852,7 @@ public class Npc extends Creature {
 		}
 	}
 	
-	public Vector<Item> getStashItems(){
+	public List<Item> getStashItems(){
 		return StashItems;
 	}
 
@@ -955,7 +943,6 @@ public class Npc extends Creature {
 	public int getSpecialType(){
 		return SpecialType;
 	}
-
 
 	public boolean isElite() {
 		return elite;

--- a/SERVER/src/creature/PlayerCharacter.java
+++ b/SERVER/src/creature/PlayerCharacter.java
@@ -14,6 +14,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Vector;
 import java.util.Map.Entry;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -518,9 +519,9 @@ public class PlayerCharacter extends Creature {
 	public void loadAbilities(){
 		ResultSet rs = Server.userDB.askDB("select * from character_ability where CharacterId = "+dbId);
 
-		abilities.clear();
+		abilities = null;
 
-		Vector<Integer> abilitiesToRemove = new Vector<Integer>();
+		List<Integer> abilitiesToRemove = new ArrayList<Integer>();
 		
 		boolean hasSoulStone = false;
 		
@@ -536,7 +537,7 @@ public class PlayerCharacter extends Creature {
 						newAB.setDbId(rs.getInt("Id"));
 						newAB.setCooldownLeft(rs.getInt("CooldownLeft"));
 						newAB.setCaster(CreatureType.Player,this);
-						abilities.add(newAB);
+						addAbility(newAB);
 					}else{
 						abilitiesToRemove.add(newAB.getAbilityId());
 					}
@@ -548,11 +549,11 @@ public class PlayerCharacter extends Creature {
 		}
 		
 		if(getAdminLevel() == 5){
-			abilities.add(AbilityHandler.getAbility(31));
-			abilities.add(AbilityHandler.getAbility(39));
-			abilities.add(AbilityHandler.getAbility(83));
-			abilities.add(AbilityHandler.getAbility(84));
-			abilities.add(AbilityHandler.getAbility(54));
+			addAbility(AbilityHandler.getAbility(31));
+			addAbility(AbilityHandler.getAbility(39));
+			addAbility(AbilityHandler.getAbility(83));
+			addAbility(AbilityHandler.getAbility(84));
+			addAbility(AbilityHandler.getAbility(54));
 		}
 		
 		// Check if soul stone should be added
@@ -563,7 +564,7 @@ public class PlayerCharacter extends Creature {
 					if(shopCheck.getInt("SoulStone") == 1){
 						// Add soul stone!
 						Server.userDB.updateDB("insert into character_ability (CharacterId,AbilityId,CooldownLeft) values ("+getDBId()+",31,0)");
-						abilities.add(AbilityHandler.getAbility(31));
+						addAbility(AbilityHandler.getAbility(31));
 					}
 				}
 				shopCheck.close();

--- a/SERVER/src/data_handlers/ability_handler/StatusEffect.java
+++ b/SERVER/src/data_handlers/ability_handler/StatusEffect.java
@@ -46,7 +46,7 @@ public class StatusEffect {
 		
 		try {
 			if(rs.next()){
-				setName(rs.getString("Name"));
+				setName(rs.getString("Name").intern());
 				StatsModif = new Stats();
 				StatsModif.reset();
 				
@@ -65,7 +65,7 @@ public class StatusEffect {
 				
 				setDuration(rs.getInt("Duration"));
 				setRepeatDamage(rs.getInt("RepeatDamage"));
-				setRepeatDamageType(rs.getString("RepeatDamageType"));
+				setRepeatDamageType(rs.getString("RepeatDamageType").intern());
 				String colorInfo[] = rs.getString("Color").split(",");
 				SEColor = new Color(Integer.parseInt(colorInfo[0]),Integer.parseInt(colorInfo[1]),Integer.parseInt(colorInfo[2]));
 				setClassId(rs.getInt("ClassId"));

--- a/SERVER/src/map/Tile.java
+++ b/SERVER/src/map/Tile.java
@@ -1,7 +1,6 @@
 package map;
 
-import java.util.Iterator;
-import java.util.Vector;
+import java.util.*;
 
 import creature.Creature;
 import creature.Creature.CreatureType;
@@ -10,6 +9,7 @@ import data_handlers.ability_handler.StatusEffect;
 import data_handlers.item_handler.Item;
 
 public class Tile {
+	
 	private String Type;
 	private String Name;
 	private boolean Passable;
@@ -48,7 +48,7 @@ public class Tile {
 	// OVERLAY OBJECT
 	
 	// STATUSEFFCT
-	private Vector<StatusEffect> statusEffects;
+	private List<StatusEffect> statusEffects = new ArrayList(4);
 	
 	
 	private boolean damaged = false;
@@ -63,8 +63,6 @@ public class Tile {
 		LootBag = new Vector<Item>();
 	//	healTimer = new Timer();
 		setMonsterLocked(false);
-		
-		statusEffects = new Vector<StatusEffect>();
 	}
 	
 	
@@ -233,7 +231,7 @@ public class Tile {
 		 */
 	}
 
-	public synchronized void addStatusEffects(Vector<StatusEffect> newStatusEffects){
+	public synchronized void addStatusEffects(List<StatusEffect> newStatusEffects){
 		for(Iterator<StatusEffect> iter = newStatusEffects.iterator();iter.hasNext();){  
 			StatusEffect s = iter.next();
 			StatusEffect mySE = getStatusEffect(s.getId());
@@ -247,18 +245,18 @@ public class Tile {
 				newSE.setCaster(s.getCaster());
 				newSE.setAbility(s.getAbility());
 				newSE.start();
-				getStatusEffects().add(newSE);
+				statusEffects.add(newSE);
 			}
 		}
 	}
 	
-	public synchronized Vector<StatusEffect> getStatusEffects(){
+	public synchronized List<StatusEffect> getStatusEffects(){
 		return statusEffects;
 	}
 	
 	public StatusEffect getStatusEffect(int sId){
 		
-		for(Iterator<StatusEffect> iter = getStatusEffects().iterator();iter.hasNext();){  
+		for(Iterator<StatusEffect> iter = getStatusEffects().iterator();iter.hasNext();){
 			StatusEffect s = iter.next();
 			if(s.getId() == sId){
 				return s;
@@ -269,17 +267,20 @@ public class Tile {
 	
 	
 	public synchronized String updateStatusEffect(){
-		String sToRemove = "";
+		if (statusEffects.isEmpty()) {
+			return "";
+		}
+		StringBuilder sToRemove = new StringBuilder(100);
 		
-		for(Iterator<StatusEffect> iter = getStatusEffects().iterator();iter.hasNext();){  
+		for(Iterator<StatusEffect> iter = statusEffects.iterator();iter.hasNext();){  
 			StatusEffect s = iter.next();
 			
 			if(!s.isActive()){
-				sToRemove += s.getId()+",";
+				sToRemove.append(s.getId()).append(',');
 				iter.remove();
 			}
 		}
-		return sToRemove;
+		return sToRemove.toString();
 	}
 	
 

--- a/SERVER/src/map/WorldMap.java
+++ b/SERVER/src/map/WorldMap.java
@@ -97,8 +97,8 @@ public class WorldMap implements TileBasedMap {
 			while(tileInfo.next()){
 				Tile newTile =  new Tile(tileInfo.getInt("X"),tileInfo.getInt("Y"),tileInfo.getInt("Z"));
 				newTile.setZ(tileInfo.getInt("Z"));
-				newTile.setType(tileInfo.getString("Type"), tileInfo.getString("Name"), tileInfo.getInt("Passable"));
-				newTile.setObjectId(tileInfo.getString("ObjectId"));
+				newTile.setType(tileInfo.getString("Type").intern(), tileInfo.getString("Name").intern(), tileInfo.getInt("Passable"));
+				newTile.setObjectId(tileInfo.getString("ObjectId").intern());
 				newTile.setDoorId(tileInfo.getInt("DoorId"));
 				newTile.setAreaEffectId(tileInfo.getInt("AreaEffectId"));
 
@@ -202,9 +202,10 @@ public class WorldMap implements TileBasedMap {
 
 		try {
 			while(containerInfo.next()){
-				if(MapTiles.get(containerInfo.getInt("X")+","+containerInfo.getInt("Y")+","+containerInfo.getInt("Z")) != null){
-					MapTiles.get(containerInfo.getInt("X")+","+containerInfo.getInt("Y")+","+containerInfo.getInt("Z")).setObjectId(containerInfo.getString("Type"));
-					MapTiles.get(containerInfo.getInt("X")+","+containerInfo.getInt("Y")+","+containerInfo.getInt("Z")).setContainerId(containerInfo.getInt("Id"));
+				String coordStr = containerInfo.getInt("X")+","+containerInfo.getInt("Y")+","+containerInfo.getInt("Z");
+				if(MapTiles.get(coordStr) != null){
+					MapTiles.get(coordStr).setObjectId(containerInfo.getString("Type").intern());
+					MapTiles.get(coordStr).setContainerId(containerInfo.getInt("Id"));
 				}
 			}
 			containerInfo.close();
@@ -253,14 +254,14 @@ public class WorldMap implements TileBasedMap {
 				tempNpc.setAggroType(creatureInfo.getInt("AggroType"));
 				tempNpc.setOriginalAggroType(creatureInfo.getInt("AggroType"));
 
-				if(!creatureInfo.getString("Name").equals("")){
-					tempNpc.setName(creatureInfo.getString("Name"));
+				if(!creatureInfo.getString("Name").isEmpty()){
+					tempNpc.setName(creatureInfo.getString("Name").intern());
 				}
 
 				tempNpc.setCreatureType(CreatureType.Monster);
 				
 				// Sets eventual equipment
-				String equipmentInfo = creatureInfo.getString("Equipment");
+				String equipmentInfo = creatureInfo.getString("Equipment").intern();
 				if(!equipmentInfo.equals("None")){
 					String equipment[] = equipmentInfo.split(",");
 					


### PR DESCRIPTION
The biggest memory usage is in WorldMap, and more specifically the Tile and Npc strings and vectors. Additionally, vector iterators are an expensive source of objects creation/destruction because they are a synchronized collection, which is unnecessary in most cases.
- intern map strings to save space
- abilities collection starts null and is allocated (small) only when necessary
- allocate initially small empty collections for Tiles status effect. Keeping them null as default seems more expensive than just allocating small lists.
- replace vector by arraylist for cheaper iterators
