### PR TITLE
Fix for bug where ability should apply to caster but ...

### DIFF
--- a/SERVER/src/data_handlers/ability_handler/AbilityHandler.java
+++ b/SERVER/src/data_handlers/ability_handler/AbilityHandler.java
@@ -1067,6 +1067,12 @@ public class AbilityHandler extends Handler {
 
                 // ADD DAMAGE, ADD STATUSEFFECTS TO TARGET
                 if (TARGET != null) {
+                  // Caster on the same tile as target? Then force ability to caster.
+                  if (CASTER.getX() == TARGET.getX()
+                      && CASTER.getY() == TARGET.getY()
+                      && CASTER.getZ() == TARGET.getZ()) {
+                    TARGET = CASTER;
+                  }
 
                   int damage = 0;
 


### PR DESCRIPTION
... is applied to the other creature on the same tile. This can happen when passing a door and there's already somebody on the destination tile. Hard to reproduce, so I did not test it in-game, but the code is small enough to rely on review only.
