### PR TITLE
Fast brush

### DIFF
--- a/EDITOR/src/game/BP_EDITOR.java
+++ b/EDITOR/src/game/BP_EDITOR.java
@@ -248,22 +248,22 @@ public class BP_EDITOR extends BasicGame {
   public static void loadScreen() {
     /*
     for(int i = 0; i < 22; i++){
-    	for(int j = 0; j < 14; j++){
+      for(int j = 0; j < 14; j++){
 
-    		ResultSet tileInfo = mapDB.askDB("select X, Y, Z, Type, Number from area_tile where X = "+(PLAYER_X-TILE_HALF_W+i)+" and Y = "+(PLAYER_Y-TILE_HALF_H+j)+" and Z = "+PLAYER_Z);
-    		try {
-    			if(tileInfo.next()){
-    				SCREEN_TILES[i][j].setType(tileInfo.getString("Type"), tileInfo.getInt("Number"));
-    			}else{
-    				SCREEN_TILES[i][j].setType("None", 0);
-    			}
-    			tileInfo.close();
-    		} catch (SQLException e) {
-    			// TODO Auto-generated catch block
-    			e.printStackTrace();
-    		}
+        ResultSet tileInfo = mapDB.askDB("select X, Y, Z, Type, Number from area_tile where X = "+(PLAYER_X-TILE_HALF_W+i)+" and Y = "+(PLAYER_Y-TILE_HALF_H+j)+" and Z = "+PLAYER_Z);
+        try {
+          if(tileInfo.next()){
+            SCREEN_TILES[i][j].setType(tileInfo.getString("Type"), tileInfo.getInt("Number"));
+          }else{
+            SCREEN_TILES[i][j].setType("None", 0);
+          }
+          tileInfo.close();
+        } catch (SQLException e) {
+          // TODO Auto-generated catch block
+          e.printStackTrace();
+        }
 
-    	}
+      }
     }
     */
 
@@ -1152,6 +1152,8 @@ public class BP_EDITOR extends BasicGame {
 
       boolean passable = false;
 
+      mapDB.updateDB("BEGIN TRANSACTION");
+
       for (int i = screenX; i < screenX + BrushSize; i++) {
         for (int j = screenY; j < screenY + BrushSize; j++) {
           if (i > 0 && i < 21 && j > 0 && j < 13) {
@@ -1271,12 +1273,14 @@ public class BP_EDITOR extends BasicGame {
           }
         }
       }
+      mapDB.updateDB("END TRANSACTION");
 
     } else {
       String tileName = MouseTile.getName();
       String tileType = MouseTile.getType();
       String saveName = MouseTile.getName();
 
+      mapDB.updateDB("BEGIN TRANSACTION");
       for (int i = screenX; i < screenX + BrushSize; i++) {
         for (int j = screenY; j < screenY + BrushSize; j++) {
           Tile checkTile = new Tile(0, 0, PLAYER_Z);
@@ -1346,6 +1350,7 @@ public class BP_EDITOR extends BasicGame {
           }
         }
       }
+      mapDB.updateDB("END TRANSACTION");
     }
     /*
 

--- a/EDITOR/src/game/BP_EDITOR.java
+++ b/EDITOR/src/game/BP_EDITOR.java
@@ -684,10 +684,10 @@ public class BP_EDITOR extends BasicGame {
         }
       }
 
-      if (INPUT.isKeyPressed(Input.KEY_1)) {
+      if (INPUT.isKeyPressed(Input.KEY_1) && BrushSize>1) {
         BrushSize--;
       }
-      if (INPUT.isKeyPressed(Input.KEY_2)) {
+      if (INPUT.isKeyPressed(Input.KEY_2) && BrushSize<8) {
         BrushSize++;
       }
 
@@ -1126,22 +1126,26 @@ public class BP_EDITOR extends BasicGame {
     return false;
   }
 
+  public static boolean canFixEdges(String tileName) {
+    return (tileName.contains("D")
+        && !tileName.contains("Stairs")
+        && !tileName.contains("Entrance")
+        && !tileName.contains("Exit")
+        && !tileName.contains("wall"));
+  }
+
+
+
   public static void addTiles(int screenX, int screenY) {
-    if (MouseTile.getName().contains("D")
-        && FixEdges
-        && !MouseTile.getName().contains("Stairs")
-        && !MouseTile.getName().contains("Entrance")
-        && !MouseTile.getName().contains("Exit")
-        && !MouseTile.getName().contains("wall")) {
+    String tileName = MouseTile.getName();
+    if (FixEdges && BrushSize>1 && canFixEdges(tileName)) {
 
-      String tileName = MouseTile.getName();
       String tileType = MouseTile.getType();
-      String otherType =
-          MouseTile.getName()
-              .substring(
-                  0,
-                  MouseTile.getName().length() - 1); //SCREEN_TILES[screenX][screenY][1].getType();
-
+      int lastChar = MouseTile.getName().length() - 1;
+      while (lastChar>0 &&  Character.isUpperCase(tileName.charAt(lastChar))) {
+        -- lastChar;
+      }
+      String otherType = tileName.substring(0, lastChar);
       //String saveTileType = MouseTile.getType();
 
       for (int i = screenX; i < screenX + BrushSize; i++) {
@@ -1276,9 +1280,8 @@ public class BP_EDITOR extends BasicGame {
       mapDB.updateDB("END TRANSACTION");
 
     } else {
-      String tileName = MouseTile.getName();
       String tileType = MouseTile.getType();
-      String saveName = MouseTile.getName();
+      String saveName = tileName;
 
       mapDB.updateDB("BEGIN TRANSACTION");
       for (int i = screenX; i < screenX + BrushSize; i++) {

--- a/EDITOR/src/gui/TextureButton.java
+++ b/EDITOR/src/gui/TextureButton.java
@@ -9,6 +9,9 @@ import org.newdawn.slick.Graphics;
 
 public class TextureButton {
 
+  public final static Color BLACK = new Color(0, 0, 0, 255);
+  public final static Color WHITE = new Color(255, 255, 255, 255);
+
   private Sprite ButtonImage;
   private int X = 0;
   private int Y = 0;
@@ -75,20 +78,31 @@ public class TextureButton {
 
     if (type.equals("Folder")) {
       ButtonImage.draw(X, Y);
-      g.setColor(new Color(0, 0, 0, 255));
+      g.setColor(BLACK);
       g.setFont(BP_EDITOR.FONTS.size8);
       g.drawString(name, X + 10, Y + 30);
     } else if (type.equals("Back")) {
       ButtonImage.draw(X, Y);
-      g.setColor(new Color(0, 0, 0, 255));
+      g.setColor(BLACK);
       g.setFont(BP_EDITOR.FONTS.size8);
       g.drawString("..", X + 10, Y + 30);
     } else if (type.equals("Delete")) {
       ButtonImage.draw(X, Y);
+      ButtonImage.draw(X, Y);
+      g.setColor(WHITE);
+      g.drawRect(X, Y, width, height);
     } else {
       ButtonImage.draw(X, Y);
-      g.setColor(new Color(255, 255, 255, 255));
+      g.setColor(WHITE);
       g.drawRect(X, Y, width, height);
+      if (name.contains("D")) {
+        g.setColor(BLACK);
+        g.setFont(BP_EDITOR.FONTS.size12bold);
+        g.drawString("F", X + 7, Y + 7);
+        g.setColor(WHITE);
+        g.setFont(BP_EDITOR.FONTS.size12bold);
+        g.drawString("F", X + 5, Y + 5);
+      }
     }
 
     if (X < mouseX && X + width > mouseX && Y < mouseY && Y + height > mouseY) {

--- a/EDITOR/src/gui/TextureButton.java
+++ b/EDITOR/src/gui/TextureButton.java
@@ -95,7 +95,7 @@ public class TextureButton {
       ButtonImage.draw(X, Y);
       g.setColor(WHITE);
       g.drawRect(X, Y, width, height);
-      if (name.contains("D")) {
+      if (BP_EDITOR.canFixEdges(name)) {
         g.setColor(BLACK);
         g.setFont(BP_EDITOR.FONTS.size12bold);
         g.drawString("F", X + 7, Y + 7);


### PR DESCRIPTION
Brushes are slow because of multiple writes in the DB. Grouping them in transactions makes the brushes as fast as individual tiles. 
Additionally, fix edges is a very useful but cryptic feature. I added an F printed on the tiles triggering the edges with brushes.
